### PR TITLE
[interval] Add typing for interval

### DIFF
--- a/src/main/java/leekscript/compiler/bloc/MainLeekBlock.java
+++ b/src/main/java/leekscript/compiler/bloc/MainLeekBlock.java
@@ -93,6 +93,7 @@ public class MainLeekBlock extends AbstractLeekBlock {
 			addClass(new ClassDeclarationInstruction(new Token("Array"), 0, ai, true, this, Type.ARRAY));
 			if (ai.getVersion() >= 4) {
 				addClass(new ClassDeclarationInstruction(new Token("Map"), 0, ai, true, this, Type.MAP));
+				addClass(new ClassDeclarationInstruction(new Token("Interval"), 0, ai, true, this, Type.INTERVAL));
 			}
 			addClass(new ClassDeclarationInstruction(new Token("String"), 0, ai, true, this, Type.STRING));
 			var objectClass = new ClassDeclarationInstruction(new Token("Object"), 0, ai, true, this, Type.OBJECT);

--- a/src/main/java/leekscript/runner/AI.java
+++ b/src/main/java/leekscript/runner/AI.java
@@ -88,6 +88,7 @@ public abstract class AI {
 	public final ClassLeekValue arrayClass;
 	public final ClassLeekValue legacyArrayClass;
 	public final ClassLeekValue mapClass;
+	public final ClassLeekValue intervalClass;
 	public final ClassLeekValue stringClass;
 	public final ClassLeekValue objectClass;
 	public final ClassLeekValue functionClass;
@@ -268,6 +269,7 @@ public abstract class AI {
 		arrayClass = new ClassLeekValue(this, "Array", valueClass);
 		legacyArrayClass = new ClassLeekValue(this, "Array", valueClass);
 		mapClass = new ClassLeekValue(this, "Map", valueClass);
+		intervalClass = new ClassLeekValue(this, "Interval", valueClass);
 		stringClass = new ClassLeekValue(this, "String", valueClass);
 		objectClass = new ClassLeekValue(this, "Object", valueClass);
 		functionClass = new ClassLeekValue(this, "Function", valueClass);
@@ -2980,6 +2982,7 @@ public abstract class AI {
 		if (value instanceof LegacyArrayLeekValue) return legacyArrayClass;
 		if (value instanceof ArrayLeekValue) return arrayClass;
 		if (value instanceof MapLeekValue) return mapClass;
+		if (value instanceof IntervalLeekValue) return intervalClass;
 		if (value instanceof String) return stringClass;
 		if (value instanceof ObjectLeekValue) return ((ObjectLeekValue) value).clazz;
 		if (value instanceof NativeObjectLeekValue)

--- a/src/main/java/leekscript/runner/values/ClassLeekValue.java
+++ b/src/main/java/leekscript/runner/values/ClassLeekValue.java
@@ -428,6 +428,10 @@ public class ClassLeekValue extends FunctionLeekValue {
 		if (this == ai.mapClass) {
 			return new MapLeekValue(ai);
 		}
+		if (this == ai.integerClass) {
+			// TODO: construct empty interval
+			return null;
+		}
 		if (this == ai.objectClass) return new ObjectLeekValue(ai, ai.objectClass);
 
 		// Create the actual object

--- a/src/test/java/test/TestInterval.java
+++ b/src/test/java/test/TestInterval.java
@@ -18,5 +18,8 @@ public class TestInterval extends TestCommon {
 		code_v4_("return 1 in [1..1];").equals("true");
 		code_v4_("return 1 in [2..1];").equals("false");
 		code_strict_v4_("boolean x = 1 in [1..1]; return x").equals("true");
+
+		section("Interval typing");
+		code_strict_v4_("Interval i = [0..10]; return i instanceof Interval").equals("true");
 	}
 }


### PR DESCRIPTION
The `Interval` is not templated because it represents a continuous range and only makes sense between numbers: `[0..10]` is no different from `[0.0 .. 10.0]`.
With this patch, strict mode works with Interval, and values can be tested with `instanceof`.

There is still no `new Interval()` but I would like to implement empty interval in a separate PR.