### PR TITLE
[interval] Implement intervalToArray

### DIFF
--- a/src/main/java/leekscript/common/Type.java
+++ b/src/main/java/leekscript/common/Type.java
@@ -38,6 +38,7 @@ public class Type {
 	public static final Type ARRAY = array(Type.ANY);
 	public static final Type INTERVAL = new Type("interval", "t", "IntervalLeekValue", "IntervalLeekValue", "new IntervalLeekValue()");
 	public static final Type ARRAY_INT = array(Type.INT);
+	public static final Type ARRAY_REAL = array(Type.REAL);
 	public static final Type ARRAY_STRING = array(Type.STRING);
 	public static final Type INT_OR_NULL = compound(Type.INT, Type.NULL);
 	public static final Type BOOL_OR_NULL = compound(Type.BOOL, Type.NULL);

--- a/src/main/java/leekscript/compiler/WordCompiler.java
+++ b/src/main/java/leekscript/compiler/WordCompiler.java
@@ -1817,7 +1817,7 @@ public class WordCompiler {
 			throw new LeekCompilerException(mTokens.get(), Error.PARENTHESIS_EXPECTED_AFTER_PARAMETERS);
 		}
 
-		return new LeekInterval(openingBracket, fromExpression, toExpression, mTokens.eat());
+		return new LeekInterval(openingBracket, fromExpression, toExpression, mTokens.get());
 	}
 	
 	private LeekAnonymousFunction readAnonymousFunction() throws LeekCompilerException {

--- a/src/main/java/leekscript/runner/LeekFunctions.java
+++ b/src/main/java/leekscript/runner/LeekFunctions.java
@@ -233,6 +233,14 @@ public class LeekFunctions {
 		method("removeKey", "Map", Type.VOID, new Type[] { Type.ARRAY, Type.ANY }).setMaxVersion(3, "mapRemove");
 
 		/**
+		 * Interval functions
+		 */
+		method("intervalToArray", "Interval", new CallableVersion[] {
+				new CallableVersion(Type.ARRAY_REAL, new Type[] { Type.INTERVAL, Type.REAL }),
+				new CallableVersion(Type.ARRAY_REAL, new Type[] { Type.INTERVAL}),
+		}).setMinVersion(4);
+
+		/**
 		 * JSON functions
 		 */
 		method("jsonEncode", "JSON", true, Type.STRING, new Type[] { Type.ANY });

--- a/src/main/java/leekscript/runner/values/IntervalLeekValue.java
+++ b/src/main/java/leekscript/runner/values/IntervalLeekValue.java
@@ -10,14 +10,14 @@ public class IntervalLeekValue {
 	private final AI ai;
 	public final int id;
 
-	private final Object from;
-	private final Object to;
+	private final double from;
+	private final double to;
 
 	public IntervalLeekValue(AI ai, Object from, Object to) throws LeekRunException {
 		this.ai = ai;
 		this.id = ai.getNextObjectID();
-		this.from = from;
-		this.to = to;
+		this.from = ai.real(from);
+		this.to = ai.real(to);
 	}
 
 	@Override
@@ -66,5 +66,26 @@ public class IntervalLeekValue {
 	public boolean contains(Object value) throws LeekRunException {
 		ai.ops(1);
 		return ai.lessequals(from, value) && ai.lessequals(value, to);
+	}
+
+	public ArrayLeekValue intervalToArray(AI ai) throws LeekRunException {
+		return intervalToArray(ai, 1);
+	}
+
+	public ArrayLeekValue intervalToArray(AI ai, double step) throws LeekRunException {
+		// Operations are added by the array
+		var array = new ArrayLeekValue(ai);
+
+		if (step >= 0.0) {
+			for (var i = from; ai.lessequals(i, to); i += step) {
+				array.push(ai, i);
+			}
+		} else {
+			for (var i = to; ai.moreequals(i, from); i += step) {
+				array.push(ai, i);
+			}
+		}
+
+		return array;
 	}
 }

--- a/src/test/java/test/TestInterval.java
+++ b/src/test/java/test/TestInterval.java
@@ -5,9 +5,9 @@ public class TestInterval extends TestCommon {
 	public void run() throws Exception {
 
 		section("Interval.constructor()");
-		code_v4_("return [1..2];").equals("[1..2]");
-		code_v4_("return [-10..-2];").equals("[-10..-2]");
-		code_v4_("return [1 * 5 .. 8 + 5];").equals("[5..13]");
+		code_v4_("return [1..2];").equals("[1.0..2.0]");
+		code_v4_("return [-10..-2];").equals("[-10.0..-2.0]");
+		code_v4_("return [1 * 5 .. 8 + 5];").equals("[5.0..13.0]");
 
 		section("Interval.in");
 		code_v4_("return 1 in [1..2];").equals("true");
@@ -21,5 +21,26 @@ public class TestInterval extends TestCommon {
 
 		section("Interval typing");
 		code_strict_v4_("Interval i = [0..10]; return i instanceof Interval").equals("true");
+
+		section("Interval.intervalToArray()");
+		code_v4_("return intervalToArray([1..2]);").equals("[1.0, 2.0]");
+		code_v4_("return intervalToArray([-2..2]);")
+				.equals("[-2.0, -1.0, 0.0, 1.0, 2.0]");
+		code_v4_("return intervalToArray([1..1]);").equals("[1.0]");
+		code_v4_("return intervalToArray([1..0]);").equals("[]");
+
+		section("Interval.intervalToArray(<step>)");
+		code_v4_("return intervalToArray([1..2], 0.8);").equals("[1.0, 1.8]");
+		code_v4_("return intervalToArray([1..2], 2);").equals("[1.0]");
+		code_v4_("return intervalToArray([-10..10], 5);").equals("[-10.0, -5.0, 0.0, 5.0, 10.0]");
+		code_v4_("return intervalToArray([1..1], 7);").equals("[1.0]");
+		code_v4_("return intervalToArray([1..0], 2);").equals("[]");
+
+		section("Interval.intervalToArray(<negative step>)");
+		code_v4_("return intervalToArray([1..2], -0.8);").equals("[2.0, 1.2]");
+		code_v4_("return intervalToArray([1..2], -2);").equals("[2.0]");
+		code_v4_("return intervalToArray([-10..10], -5);").equals("[10.0, 5.0, 0.0, -5.0, -10.0]");
+		code_v4_("return intervalToArray([1..1], -7);").equals("[1.0]");
+		code_v4_("return intervalToArray([1..0], -2);").equals("[]");
 	}
 }


### PR DESCRIPTION
- Fix an issue where the token after an interval is always eaten
- Interval stores double internally
- Implements `intervalToArray(step = 1)` which returns an array with all the expected values, the step can be negative; it's equivalent to `for(var i = from; i <= to; i+= step) arr.push(i)`