### PR TITLE
[interval] Add getters

### DIFF
--- a/src/main/java/leekscript/runner/AI.java
+++ b/src/main/java/leekscript/runner/AI.java
@@ -783,6 +783,8 @@ public abstract class AI {
 			return ((LegacyArrayLeekValue) value).size() != 0;
 		} else if (value instanceof ArrayLeekValue) {
 			return ((ArrayLeekValue) value).size() != 0;
+		} else if (value instanceof IntervalLeekValue) {
+			return !((IntervalLeekValue) value).intervalIsEmpty(this);
 		} else if (value instanceof MapLeekValue) {
 			return ((MapLeekValue) value).size() != 0;
 		} else if (value instanceof IntervalLeekValue) {

--- a/src/main/java/leekscript/runner/LeekFunctions.java
+++ b/src/main/java/leekscript/runner/LeekFunctions.java
@@ -235,6 +235,9 @@ public class LeekFunctions {
 		/**
 		 * Interval functions
 		 */
+		method("intervalLowerBound", "Interval", 1, Type.REAL, new Type[] { Type.INTERVAL }).setMinVersion(4);
+		method("intervalUpperBound", "Interval", 1, Type.REAL, new Type[] { Type.INTERVAL }).setMinVersion(4);
+		method("intervalIsEmpty", "Interval", 1, Type.BOOL, new Type[] { Type.INTERVAL }).setMinVersion(4);
 		method("intervalToArray", "Interval", new CallableVersion[] {
 				new CallableVersion(Type.ARRAY_REAL, new Type[] { Type.INTERVAL, Type.REAL }),
 				new CallableVersion(Type.ARRAY_REAL, new Type[] { Type.INTERVAL}),

--- a/src/main/java/leekscript/runner/values/IntervalLeekValue.java
+++ b/src/main/java/leekscript/runner/values/IntervalLeekValue.java
@@ -63,10 +63,22 @@ public class IntervalLeekValue {
 		return sb.append("]").toString();
 	}
 
+	public double intervalLowerBound(AI ai) {
+		return from;
+	}
+
+	public double intervalUpperBound(AI ai) {
+		return to;
+	}
+
+	public boolean intervalIsEmpty(AI ai) {
+		return to < from;
+	}
+
 	public boolean operatorIn(Object value) throws LeekRunException {
 		ai.ops(1);
 		var valueAsReal = ai.real(value);
-		return ai.lessequals(from, valueAsReal) && ai.lessequals(valueAsReal, to);
+		return from <= valueAsReal && valueAsReal <= to;
 	}
 
 	public ArrayLeekValue intervalToArray(AI ai) throws LeekRunException {
@@ -78,11 +90,11 @@ public class IntervalLeekValue {
 		var array = new ArrayLeekValue(ai);
 
 		if (step >= 0.0) {
-			for (var i = from; ai.lessequals(i, to); i += step) {
+			for (var i = from; i <= to; i += step) {
 				array.push(ai, i);
 			}
 		} else {
-			for (var i = to; ai.moreequals(i, from); i += step) {
+			for (var i = to; i >= from; i += step) {
 				array.push(ai, i);
 			}
 		}

--- a/src/test/java/test/TestInterval.java
+++ b/src/test/java/test/TestInterval.java
@@ -9,6 +9,32 @@ public class TestInterval extends TestCommon {
 		code_v4_("return [-10..-2];").equals("[-10.0..-2.0]");
 		code_v4_("return [1 * 5 .. 8 + 5];").equals("[5.0..13.0]");
 
+		section("Interval.intervalLowerBound");
+		code_v4_("return intervalLowerBound([1..2]);").equals("1.0");
+		code_v4_("return intervalLowerBound([-10..-2]);").equals("-10.0");
+		code_v4_("return intervalLowerBound([1 * 5 .. 8 + 5]);").equals("5.0");
+		code_v4_("return intervalLowerBound([1..1]);").equals("1.0");
+		code_v4_("return intervalLowerBound([1..0]);").equals("1.0");
+
+		section("Interval.intervalUpperBound");
+		code_v4_("return intervalUpperBound([1..2]);").equals("2.0");
+		code_v4_("return intervalUpperBound([-10..-2]);").equals("-2.0");
+		code_v4_("return intervalUpperBound([1 * 5 .. 8 + 5]);").equals("13.0");
+		code_v4_("return intervalUpperBound([1..1]);").equals("1.0");
+		code_v4_("return intervalUpperBound([1..0]);").equals("0.0");
+
+		section("Interval.intervalIsEmpty");
+		code_v4_("return intervalIsEmpty([1..2]);").equals("false");
+		code_v4_("return intervalIsEmpty([-10..-2]);").equals("false");
+		code_v4_("return intervalIsEmpty([1..1]);").equals("false");
+		code_v4_("return intervalIsEmpty([1..0]);").equals("true");
+
+		section("Interval as boolean");
+		code_v4_("return !![1..2];").equals("true");
+		code_v4_("return !![-10..-2];").equals("true");
+		code_v4_("return !![1..1];").equals("true");
+		code_v4_("return !![1..0];").debug().equals("false");
+
 		section("Interval.in");
 		code_v4_("return 1 in [1..2];").equals("true");
 		code_v4_("return 1 in [0..2];").equals("true");
@@ -24,8 +50,7 @@ public class TestInterval extends TestCommon {
 
 		section("Interval.intervalToArray()");
 		code_v4_("return intervalToArray([1..2]);").equals("[1.0, 2.0]");
-		code_v4_("return intervalToArray([-2..2]);")
-				.equals("[-2.0, -1.0, 0.0, 1.0, 2.0]");
+		code_v4_("return intervalToArray([-2..2]);").equals("[-2.0, -1.0, 0.0, 1.0, 2.0]");
 		code_v4_("return intervalToArray([1..1]);").equals("[1.0]");
 		code_v4_("return intervalToArray([1..0]);").equals("[]");
 


### PR DESCRIPTION
Implements the following trivial getters:
- `intervalUpperBound`
- `intervalLowerBound`
- `intervalIsEmpty` & `bool(<interval>)`

Each is 1 op.