### PR TITLE
[interval] Test ops

### DIFF
--- a/src/main/java/leekscript/runner/values/IntervalLeekValue.java
+++ b/src/main/java/leekscript/runner/values/IntervalLeekValue.java
@@ -99,6 +99,8 @@ public class IntervalLeekValue {
 			}
 		}
 
+		ai.ops(array.size() * 2);
+
 		return array;
 	}
 }

--- a/src/test/java/test/TestInterval.java
+++ b/src/test/java/test/TestInterval.java
@@ -8,6 +8,7 @@ public class TestInterval extends TestCommon {
 		code_v4_("return [1..2];").equals("[1.0..2.0]");
 		code_v4_("return [-10..-2];").equals("[-10.0..-2.0]");
 		code_v4_("return [1 * 5 .. 8 + 5];").equals("[5.0..13.0]");
+		code_v4_("[1..2]").ops(2);
 
 		section("Interval.intervalLowerBound");
 		code_v4_("return intervalLowerBound([1..2]);").equals("1.0");
@@ -44,6 +45,7 @@ public class TestInterval extends TestCommon {
 		code_v4_("return 1 in [1..1];").equals("true");
 		code_v4_("return 1 in [2..1];").equals("false");
 		code_strict_v4_("boolean x = 1 in [1..1]; return x").equals("true");
+		code_v4_("1 in [1..2]").ops(4);
 
 		section("Interval typing");
 		code_strict_v4_("Interval i = [0..10]; return i instanceof Interval").equals("true");
@@ -53,6 +55,7 @@ public class TestInterval extends TestCommon {
 		code_v4_("return intervalToArray([-2..2]);").equals("[-2.0, -1.0, 0.0, 1.0, 2.0]");
 		code_v4_("return intervalToArray([1..1]);").equals("[1.0]");
 		code_v4_("return intervalToArray([1..0]);").equals("[]");
+		code_v4_("intervalToArray([1..2])").ops(6);
 
 		section("Interval.intervalToArray(<step>)");
 		code_v4_("return intervalToArray([1..2], 0.8);").equals("[1.0, 1.8]");


### PR DESCRIPTION
- Add some tests on operations count for interval methods.
- Fix `intervalToArray` being free, now count as 2 ops per value, equivalent to creating the array with these values.