### PR TITLE
[parser] Fix number parsing in interval

### DIFF
--- a/src/main/java/leekscript/compiler/LexicalParser.java
+++ b/src/main/java/leekscript/compiler/LexicalParser.java
@@ -187,13 +187,13 @@ public class LexicalParser {
 			}
 
 			if (c == '.') {
-				if (stream.getSubStringSince(startingPoint).contains(".")) {
-					error.report(new AnalyzeError(new Token(TokenType.NOTHING, ".", aiFile, stream.getLineCounter(), stream.getCharCounter() + 1), AnalyzeErrorLevel.ERROR, Error.INVALID_CHAR));
+				// We don't eat the dot if it's followed by another dot
+				if (stream.peek(1) == '.') {
 					break;
 				}
 
-				// We don't eat the dot if it's not followed by another dot
-				if (stream.peek(1) == '.') {
+				if (stream.getSubStringSince(startingPoint).contains(".")) {
+					error.report(new AnalyzeError(new Token(TokenType.NOTHING, ".", aiFile, stream.getLineCounter(), stream.getCharCounter() + 1), AnalyzeErrorLevel.ERROR, Error.INVALID_CHAR));
 					break;
 				}
 

--- a/src/test/java/test/TestInterval.java
+++ b/src/test/java/test/TestInterval.java
@@ -9,9 +9,8 @@ public class TestInterval extends TestCommon {
 		section("Interval.constructor()");
 		code("return [..]").equals("[..]");
 		code("return [1..2]").equals("[1..2]");
-		DISABLED_code("return [1.0..2.0]").equals("[1.0..2.0]");
-		code_v1("return [1.0 .. 2.0]").equals("[1..2]");
-		code_v2_("return [1.0 .. 2.0]").equals("[1.0..2.0]");
+		code_v1("return [1.0..2.0]").equals("[1..2]");
+		code_v2_("return [1.0..2.0]").equals("[1.0..2.0]");
 		code("return [-10..-2]").equals("[-10..-2]");
 		code("return [1 * 5 .. 8 + 5]").equals("[5..13]");
 		code("return ]-∞..5]").equals("]-∞..5]");


### PR DESCRIPTION
#21

The parser for numbers is a bit weird as it eagerly eats all the dots. 
Now they are only eaten if the dot is not part of `..`.