### PR TITLE
Add BigIntegers

### DIFF
--- a/src/main/java/leekscript/common/BigIntegerType.java
+++ b/src/main/java/leekscript/common/BigIntegerType.java
@@ -1,0 +1,41 @@
+package leekscript.common;
+
+import leekscript.compiler.JavaWriter;
+
+public class BigIntegerType extends Type {
+
+	public BigIntegerType() {
+		super("big_integer", "l", "BigIntegerValue", "BigIntegerValue", "new BigIntegerValue()");
+	}
+	
+	@Override
+	public String getDefaultValue(JavaWriter writer, int version) {
+		return "new BigIntegerValue(" + writer.getAIThis() + ", 0)";
+	}
+	
+	@Override
+	public boolean canBeIterable() {
+		return false;
+	}
+
+	@Override
+	public boolean isIterable() {
+		return false;
+	}
+	
+	@Override
+	public boolean canBeCallable() {
+		return false;
+	}
+	
+	@Override
+	public boolean isIndexable() {
+		return true;
+	}
+
+	@Override
+	public boolean canBeIndexable() {
+		return true;
+	}
+	
+}

--- a/src/main/java/leekscript/common/CompoundType.java
+++ b/src/main/java/leekscript/common/CompoundType.java
@@ -185,8 +185,8 @@ public class CompoundType extends Type {
 	}
 
 
-	public boolean isIntOrReal() {
-		return types.size() == 2 && types.contains(Type.INT) && types.contains(Type.REAL);
+	public boolean isCompoundNumber() {
+		return types.size() >= 2 && types.stream().allMatch(t -> t.isNumber());
 	}
 
 	public String getJavaPrimitiveName(int version) {

--- a/src/main/java/leekscript/common/IntervalType.java
+++ b/src/main/java/leekscript/common/IntervalType.java
@@ -10,6 +10,7 @@ public class IntervalType extends Type {
 		this(type, false);
 	}
 
+	// TODO add BIG_INT
 	public IntervalType(Type type, boolean infinite) {
 		super(infinite ? "Interval<infinite>" : type == Type.VOID ? "Interval<empty>" : type == Type.ANY ? "Interval" : "Interval<" + type.toString() + ">", "t", "IntervalLeekValue", "IntervalLeekValue", type == Type.INT ? "new IntegerIntervalLeekValue()" : "new RealIntervalLeekValue()");
 		this.type = type;

--- a/src/main/java/leekscript/compiler/JavaWriter.java
+++ b/src/main/java/leekscript/compiler/JavaWriter.java
@@ -196,17 +196,23 @@ public class JavaWriter {
 
 	public void compileConvert(MainLeekBlock mainblock, int index, Expression value, Type type) {
 
-		// System.out.println("convert " + value.getType() + " to " + type);
-		if (type == Type.REAL && value.getType().isIntOrReal()) {
-			addCode("(");
+//		 System.out.println("convert " + value.getType().getJavaName(4) + " to " + type.getJavaName(4));
+		if (type == Type.REAL && value.getType().isCompoundNumber()) {
+			addCode("((Number) (");
 			value.writeJavaCode(mainblock, this);
-			addCode(").doubleValue()");
+			addCode(")).doubleValue()");
 			return;
 		}
-		if (type == Type.INT && value.getType().isIntOrReal()) {
-			addCode("(");
+		if (type == Type.INT && value.getType().isCompoundNumber()) {
+			addCode("((Number) (");
 			value.writeJavaCode(mainblock, this);
-			addCode(").longValue()");
+			addCode(")).longValue()");
+			return;
+		}
+		if (type == Type.BIG_INT && value.getType().isNumber()) {
+			addCode("BigIntegerValue.valueOf(" + getAIThis() + ", ");
+			value.writeJavaCode(mainblock, this);
+			addCode(")");
 			return;
 		}
 		var cast = type.accepts(value.getType());
@@ -235,6 +241,11 @@ public class JavaWriter {
 				value.writeJavaCode(mainblock, this);
 				addCode(")");
 				return;
+			} else {
+				addCode("longint(");
+				value.writeJavaCode(mainblock, this);
+				addCode(")");
+				return;
 			}
 		} else if (type == Type.REAL) {
 			if (value.getType() == Type.INT) {
@@ -248,8 +259,13 @@ public class JavaWriter {
 				addCode(")");
 				return;
 			}
+		} else if (type == Type.BIG_INT) {
+			addCode("bigint(");
+			value.writeJavaCode(mainblock, this);
+			addCode(")");
+			return;
 		}
-		// int?, real?
+		// int?, real?, big_integer?
 		if (type instanceof CompoundType ct) {
 			if (ct.getTypes().size() == 2) {
 				if (ct.getTypes().stream().anyMatch(t -> t == Type.NULL)) {
@@ -263,6 +279,24 @@ public class JavaWriter {
 							}
 							if (t == Type.INT && value.getType() == Type.REAL) { // double -> Integer
 								addCode("((long) (");
+								value.writeJavaCode(mainblock, this);
+								addCode("))");
+								return;
+							}
+							if (t == Type.INT && value.getType() == Type.BIG_INT) { // bigint -> Integer
+								addCode("((");
+								value.writeJavaCode(mainblock, this);
+								addCode(").longValue())");
+								return;
+							}
+							if (t == Type.REAL && value.getType() == Type.BIG_INT) { // bigint -> double
+								addCode("((");
+								value.writeJavaCode(mainblock, this);
+								addCode(").doubleValue())");
+								return;
+							}
+							if (t == Type.BIG_INT && value.getType().isNumber()) { // int/double -> bigint
+								addCode("(BigIntegerValue.valueOf(" + getAIThis() + ", ");
 								value.writeJavaCode(mainblock, this);
 								addCode("))");
 								return;
@@ -322,18 +356,20 @@ public class JavaWriter {
 				addCode("Object a" + a);
 			}
 			addLine(") throws LeekRunException {");
-
+			
 			// Conflicting versions ?
 			if (versions.size() > 1) {
-				var other_version = versions.get(1);
-				addCode("if (");
-				for (int a = 0; a < other_version.arguments.length; ++a) {
-					if (a > 0) addCode(" && ");
-					addCode("a" + a + " instanceof " + other_version.arguments[a].getJavaName(block.getVersion()) + " x" + a);
+				for (int i = 1; i < versions.size(); ++i) {
+					var other_version = versions.get(i);
+					addCode("if (");
+					for (int a = 0; a < other_version.arguments.length; ++a) {
+						if (a > 0) addCode(" && ");
+						addCode("a" + a + " instanceof " + other_version.arguments[a].getJavaName(block.getVersion()) + " x" + a);
+					}
+					addLine(") {");
+					writeFunctionCall(block, other_version, true);
+					addLine("}");
 				}
-				addLine(") {");
-				writeFunctionCall(block, other_version, true);
-				addLine("}");
 			}
 
 			int a = 0;
@@ -431,6 +467,9 @@ public class JavaWriter {
 		if (type == Type.INT) {
 			return "longint(" + v + ")";
 		}
+		if (type == Type.BIG_INT) {
+			return "bigint(" + v + ")";
+		}
 		if (type == Type.REAL) {
 			return "real(" + v + ")";
 		}
@@ -441,6 +480,7 @@ public class JavaWriter {
 			if (ct.getTypes().size() == 2 && ct.getTypes().stream().anyMatch(t -> t == Type.NULL)) {
 				for (var t : ct.getTypes()) {
 					if (t != Type.NULL) {
+						if (t == Type.BIG_INT) return "BigIntegerValue.valueOf(" + getAIThis() + ", " + v + ")";
 						if (t == Type.INT) return "(Long) " + v;
 						if (t == Type.REAL) return "(Double) " + v;
 						if (t == Type.BOOL) return "(Boolean) " + v;

--- a/src/main/java/leekscript/compiler/WordCompiler.java
+++ b/src/main/java/leekscript/compiler/WordCompiler.java
@@ -1,8 +1,8 @@
 package leekscript.compiler;
 
+import java.math.BigInteger;
 import java.util.HashSet;
 
-import leekscript.ErrorManager;
 import leekscript.common.AccessLevel;
 import leekscript.common.Error;
 import leekscript.common.FunctionType;
@@ -23,25 +23,27 @@ import leekscript.compiler.exceptions.LeekCompilerException;
 import leekscript.compiler.expression.Expression;
 import leekscript.compiler.expression.LeekAnonymousFunction;
 import leekscript.compiler.expression.LeekArray;
-import leekscript.compiler.expression.LegacyLeekArray;
+import leekscript.compiler.expression.LeekBigInteger;
 import leekscript.compiler.expression.LeekBoolean;
 import leekscript.compiler.expression.LeekCompoundType;
 import leekscript.compiler.expression.LeekExpression;
 import leekscript.compiler.expression.LeekExpressionException;
 import leekscript.compiler.expression.LeekFunctionCall;
+import leekscript.compiler.expression.LeekInteger;
 import leekscript.compiler.expression.LeekInterval;
 import leekscript.compiler.expression.LeekMap;
 import leekscript.compiler.expression.LeekNull;
-import leekscript.compiler.expression.LeekNumber;
 import leekscript.compiler.expression.LeekObject;
 import leekscript.compiler.expression.LeekParameterType;
 import leekscript.compiler.expression.LeekParenthesis;
+import leekscript.compiler.expression.LeekReal;
 import leekscript.compiler.expression.LeekSet;
 import leekscript.compiler.expression.LeekString;
 import leekscript.compiler.expression.LeekType;
 import leekscript.compiler.expression.LeekVariable;
-import leekscript.compiler.expression.Operators;
 import leekscript.compiler.expression.LeekVariable.VariableType;
+import leekscript.compiler.expression.LegacyLeekArray;
+import leekscript.compiler.expression.Operators;
 import leekscript.compiler.instruction.BlankInstruction;
 import leekscript.compiler.instruction.ClassDeclarationInstruction;
 import leekscript.compiler.instruction.LeekBreakInstruction;
@@ -594,6 +596,7 @@ public class WordCompiler {
 		if (word.equals("boolean")) return new LeekType(mTokens.eat(), Type.BOOL);
 		if (word.equals("any")) return new LeekType(mTokens.eat(), Type.ANY);
 		if (word.equals("integer")) return new LeekType(mTokens.eat(), Type.INT);
+		if (word.equals("big_integer")) return new LeekType(mTokens.eat(), Type.BIG_INT);
 		if (word.equals("real")) return new LeekType(mTokens.eat(), Type.REAL);
 		if (word.equals("string")) return new LeekType(mTokens.eat(), Type.STRING);
 		if (word.equals("Class")) return new LeekType(mTokens.eat(), Type.CLASS);
@@ -1576,28 +1579,43 @@ public class WordCompiler {
 					if (s.contains("__")) {
 						addError(new AnalyzeError(word, AnalyzeErrorLevel.ERROR, Error.MULTIPLE_NUMERIC_SEPARATORS));
 					}
-					try {
-						var radix = s.startsWith("0x") ? 16 : s.startsWith("0b") ? 2 : 10;
-						s = word.getWord().replace("_", "");
-						if (radix != 10) s = s.substring(2);
-						retour.addExpression(new LeekNumber(word, 0, Long.parseLong(s, radix), Type.INT));
-					} catch (NumberFormatException e) {
-						s = word.getWord().replace("_", "");
+					s = word.getWord().replace("_", "");
+					var radix = s.startsWith("0x") ? 16 : s.startsWith("0b") ? 2 : 10;
+					if (radix != 10) s = s.substring(2);
+					if (s.endsWith("L")) {
 						try {
-							retour.addExpression(new LeekNumber(word, Double.parseDouble(s), 0, Type.REAL));
-						} catch (NumberFormatException e2) {
+							s = s.substring(0, s.length() - 1);
+							retour.addExpression(new LeekBigInteger(word, new BigInteger(s, radix)));
+						} catch (NumberFormatException e) {
 							addError(new AnalyzeError(word, AnalyzeErrorLevel.ERROR, Error.INVALID_NUMBER));
-							retour.addExpression(new LeekNumber(word, 0, 0, Type.INT));
+							retour.addExpression(new LeekBigInteger(word, BigInteger.ZERO));
+						}
+					} else {
+						try {
+							try {
+								retour.addExpression(new LeekInteger(word, Long.parseLong(s, radix)));
+							} catch (NumberFormatException e2) {
+								if (s.contains(".")) throw e2;
+								// if number is too big, try to parse it as a BigInteger
+								else retour.addExpression(new LeekBigInteger(word, new BigInteger(s, radix)));
+							}
+						} catch (NumberFormatException e) {
+							s = word.getWord().replace("_", "");
+							try {
+								retour.addExpression(new LeekReal(word, Double.parseDouble(s)));
+							} catch (NumberFormatException e2) {
+								addError(new AnalyzeError(word, AnalyzeErrorLevel.ERROR, Error.INVALID_NUMBER));
+								retour.addExpression(new LeekInteger(word, 0));
+							}
 						}
 					}
-
 				} else if (word.getType() == TokenType.LEMNISCATE) {
 
-					retour.addExpression(new LeekNumber(word, Double.POSITIVE_INFINITY, 0, Type.REAL));
+					retour.addExpression(new LeekReal(word, Double.POSITIVE_INFINITY));
 
 				} else if (word.getType() == TokenType.PI) {
 
-					retour.addExpression(new LeekNumber(word, Math.PI, 0, Type.REAL));
+					retour.addExpression(new LeekReal(word, Math.PI));
 
 				} else if (word.getType() == TokenType.VAR_STRING) {
 

--- a/src/main/java/leekscript/compiler/bloc/MainLeekBlock.java
+++ b/src/main/java/leekscript/compiler/bloc/MainLeekBlock.java
@@ -10,22 +10,24 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import leekscript.common.AccessLevel;
+import leekscript.common.Error;
 import leekscript.common.Type;
 import leekscript.compiler.AIFile;
 import leekscript.compiler.IACompiler;
-import leekscript.compiler.Token;
 import leekscript.compiler.JavaWriter;
 import leekscript.compiler.Location;
 import leekscript.compiler.Options;
+import leekscript.compiler.Token;
 import leekscript.compiler.WordCompiler;
 import leekscript.compiler.exceptions.LeekCompilerException;
+import leekscript.compiler.expression.LeekBigInteger;
 import leekscript.compiler.expression.LeekExpressionException;
-import leekscript.compiler.expression.LeekNumber;
+import leekscript.compiler.expression.LeekInteger;
+import leekscript.compiler.expression.LeekReal;
 import leekscript.compiler.expression.LeekVariable.VariableType;
 import leekscript.compiler.instruction.ClassDeclarationInstruction;
 import leekscript.compiler.instruction.LeekGlobalDeclarationInstruction;
 import leekscript.runner.LeekFunctions;
-import leekscript.common.Error;
 
 public class MainLeekBlock extends AbstractLeekBlock {
 
@@ -81,15 +83,19 @@ public class MainLeekBlock extends AbstractLeekBlock {
 			addClass(new ClassDeclarationInstruction(new Token("Boolean"), 0, ai, true, this, Type.BOOL));
 
 			var integerClass = new ClassDeclarationInstruction(new Token("Integer"), 0, ai, true, this, Type.INT);
-			integerClass.addStaticField(wordCompiler, new Token("MIN_VALUE"), Type.INT, new LeekNumber(new Token(""), 0, Long.MIN_VALUE, Type.INT), AccessLevel.PUBLIC, true);
-			integerClass.addStaticField(wordCompiler, new Token("MAX_VALUE"), Type.INT, new LeekNumber(new Token(""), 0, Long.MAX_VALUE, Type.INT), AccessLevel.PUBLIC, true);
+			integerClass.addStaticField(wordCompiler, new Token("MIN_VALUE"), Type.INT, new LeekInteger(new Token(""), Long.MIN_VALUE), AccessLevel.PUBLIC, true);
+			integerClass.addStaticField(wordCompiler, new Token("MAX_VALUE"), Type.INT, new LeekInteger(new Token(""), Long.MAX_VALUE), AccessLevel.PUBLIC, true);
 			addClass(integerClass);
 
 			var realClass = new ClassDeclarationInstruction(new Token("Real"), 0, ai, true, this, Type.REAL);
-			realClass.addStaticField(wordCompiler, new Token("MIN_VALUE"), Type.REAL, new LeekNumber(new Token(""), Double.MIN_VALUE, 0, Type.REAL), AccessLevel.PUBLIC, true);
-			realClass.addStaticField(wordCompiler, new Token("MAX_VALUE"), Type.REAL, new LeekNumber(new Token(""), Double.MAX_VALUE, 0, Type.REAL), AccessLevel.PUBLIC, true);
+			realClass.addStaticField(wordCompiler, new Token("MIN_VALUE"), Type.REAL, new LeekReal(new Token(""), Double.MIN_VALUE), AccessLevel.PUBLIC, true);
+			realClass.addStaticField(wordCompiler, new Token("MAX_VALUE"), Type.REAL, new LeekReal(new Token(""), Double.MAX_VALUE), AccessLevel.PUBLIC, true);
 			addClass(realClass);
-
+			
+			if (ai.getVersion() >= 4) {
+				addClass(new ClassDeclarationInstruction(new Token("BigInteger"), 0, ai, true, this, Type.BIG_INT));
+			}
+			
 			addClass(new ClassDeclarationInstruction(new Token("Number"), 0, ai, true, this, Type.INT_OR_REAL));
 			addClass(new ClassDeclarationInstruction(new Token("Array"), 0, ai, true, this, Type.ARRAY, Type.EMPTY_ARRAY));
 			if (ai.getVersion() >= 4) {

--- a/src/main/java/leekscript/compiler/expression/LeekBigInteger.java
+++ b/src/main/java/leekscript/compiler/expression/LeekBigInteger.java
@@ -1,0 +1,41 @@
+package leekscript.compiler.expression;
+
+import java.math.BigInteger;
+
+import leekscript.common.Type;
+import leekscript.compiler.JavaWriter;
+import leekscript.compiler.Token;
+import leekscript.compiler.bloc.MainLeekBlock;
+
+public class LeekBigInteger extends LeekNumber {
+
+	private final BigInteger value;
+
+	public LeekBigInteger(Token token, BigInteger value) {
+		super(token, Type.BIG_INT);
+		this.value = value;
+	}
+
+	@Override
+	public boolean isInfinity() {
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return value.toString();
+	}
+
+	@Override
+	public void writeJavaCode(MainLeekBlock mainblock, JavaWriter writer) {
+		writer.addCode("new BigIntegerValue("+ writer.getAIThis() + ",\"" + value.toString() + "\")");
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof LeekBigInteger) {
+			return value.equals(((LeekBigInteger) o).value);
+		}
+		return false;
+	}
+}

--- a/src/main/java/leekscript/compiler/expression/LeekExpression.java
+++ b/src/main/java/leekscript/compiler/expression/LeekExpression.java
@@ -550,9 +550,20 @@ public class LeekExpression extends Expression {
 			// }
 			return;
 		case Operators.INTEGER_DIVISION: // Division entière
-			writer.getInt(mainblock, mExpression1);
-			writer.addCode(" / ");
-			writer.getInt(mainblock, mExpression2);
+			if (mExpression1.getType().isPrimitiveNumber() && mExpression2.getType().isPrimitiveNumber()) {
+				writer.getInt(mainblock, mExpression1);
+				writer.addCode(" / ");
+				writer.getInt(mainblock, mExpression2);
+			} else {
+				if (type.isPrimitive()) {
+					writer.addCode("(" + type.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
+				}
+				writer.addCode("(" + type.getJavaName(mainblock.getVersion()) + ") intdiv(");
+				mExpression1.writeJavaCode(mainblock, writer);
+				writer.addCode(", ");
+				mExpression2.writeJavaCode(mainblock, writer);
+				writer.addCode(")");
+			}
 			return;
 		case Operators.POWER: // Puissance
 			if (mExpression1.getType() == Type.NULL && mExpression2.getType() == Type.NULL) {
@@ -571,34 +582,100 @@ public class LeekExpression extends Expression {
 			return;
 			// Les binaires
 		case Operators.BITAND:
-			writer.getInt(mainblock, mExpression1);
-			writer.addCode(" & ");
-			writer.getInt(mainblock, mExpression2);
+			if (mExpression1.getType().isPrimitiveNumber() && mExpression2.getType().isPrimitiveNumber()) {
+				writer.getInt(mainblock, mExpression1);
+				writer.addCode(" & ");
+				writer.getInt(mainblock, mExpression2);
+			} else {
+				if (type.isPrimitive()) {
+					writer.addCode("(" + type.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
+				}
+				writer.addCode("(" + type.getJavaName(mainblock.getVersion()) + ") band(");
+				mExpression1.writeJavaCode(mainblock, writer);
+				writer.addCode(", ");
+				mExpression2.writeJavaCode(mainblock, writer);
+				writer.addCode(")");
+			}
 			return;
 		case Operators.BITOR:
-			writer.getInt(mainblock, mExpression1);
-			writer.addCode(" | ");
-			writer.getInt(mainblock, mExpression2);
+			if (mExpression1.getType().isPrimitiveNumber() && mExpression2.getType().isPrimitiveNumber()) {
+				writer.getInt(mainblock, mExpression1);
+				writer.addCode(" | ");
+				writer.getInt(mainblock, mExpression2);
+			} else {
+				if (type.isPrimitive()) {
+					writer.addCode("(" + type.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
+				}
+				writer.addCode("(" + type.getJavaName(mainblock.getVersion()) + ") bor(");
+				mExpression1.writeJavaCode(mainblock, writer);
+				writer.addCode(", ");
+				mExpression2.writeJavaCode(mainblock, writer);
+				writer.addCode(")");
+			}
 			return;
 		case Operators.BITXOR:
-			writer.getInt(mainblock, mExpression1);
-			writer.addCode(" ^ ");
-			writer.getInt(mainblock, mExpression2);
+			if (mExpression1.getType().isPrimitiveNumber() && mExpression2.getType().isPrimitiveNumber()) {
+				writer.getInt(mainblock, mExpression1);
+				writer.addCode(" ^ ");
+				writer.getInt(mainblock, mExpression2);
+			} else {
+				if (type.isPrimitive()) {
+					writer.addCode("(" + type.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
+				}
+				writer.addCode("(" + type.getJavaName(mainblock.getVersion()) + ") bxor(");
+				mExpression1.writeJavaCode(mainblock, writer);
+				writer.addCode(", ");
+				mExpression2.writeJavaCode(mainblock, writer);
+				writer.addCode(")");
+			}
 			return;
 		case Operators.SHIFT_LEFT:
-			writer.getInt(mainblock, mExpression1);
-			writer.addCode(" << ");
-			writer.getInt(mainblock, mExpression2);
+			if (mExpression1.getType().isPrimitiveNumber() && mExpression2.getType().isPrimitiveNumber()) {
+				writer.getInt(mainblock, mExpression1);
+				writer.addCode(" << ");
+				writer.getInt(mainblock, mExpression2);
+			} else {
+				if (type.isPrimitive()) {
+					writer.addCode("(" + type.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
+				}
+				writer.addCode("(" + type.getJavaName(mainblock.getVersion()) + ") shl(");
+				mExpression1.writeJavaCode(mainblock, writer);
+				writer.addCode(", ");
+				mExpression2.writeJavaCode(mainblock, writer);
+				writer.addCode(")");
+			}
 			return;
 		case Operators.SHIFT_RIGHT:
-			writer.getInt(mainblock, mExpression1);
-			writer.addCode(" >> ");
-			writer.getInt(mainblock, mExpression2);
+			if (mExpression1.getType().isPrimitiveNumber() && mExpression2.getType().isPrimitiveNumber()) {
+				writer.getInt(mainblock, mExpression1);
+				writer.addCode(" >> ");
+				writer.getInt(mainblock, mExpression2);
+			} else {
+				if (type.isPrimitive()) {
+					writer.addCode("(" + type.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
+				}
+				writer.addCode("(" + type.getJavaName(mainblock.getVersion()) + ") shr(");
+				mExpression1.writeJavaCode(mainblock, writer);
+				writer.addCode(", ");
+				mExpression2.writeJavaCode(mainblock, writer);
+				writer.addCode(")");
+			}
 			return;
 		case Operators.SHIFT_UNSIGNED_RIGHT:
-			writer.getInt(mainblock, mExpression1);
-			writer.addCode(" >>> ");
-			writer.getInt(mainblock, mExpression2);
+			if (mExpression1.getType().isPrimitiveNumber() && mExpression2.getType().isPrimitiveNumber()) {
+				writer.getInt(mainblock, mExpression1);
+				writer.addCode(" >>> ");
+				writer.getInt(mainblock, mExpression2);
+			} else {
+				if (type.isPrimitive()) {
+					writer.addCode("(" + type.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
+				}
+				writer.addCode("(" + type.getJavaName(mainblock.getVersion()) + ") ushr(");
+				mExpression1.writeJavaCode(mainblock, writer);
+				writer.addCode(", ");
+				mExpression2.writeJavaCode(mainblock, writer);
+				writer.addCode(")");
+			}
 			return;
 
 		// Les logiques
@@ -769,6 +846,11 @@ public class LeekExpression extends Expression {
 			writer.getBoolean(mainblock, mExpression2);
 			return;
 		case Operators.BITNOT:
+			if (type.isPrimitive()) {
+				writer.addCode("(" + type.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
+			} else {
+				writer.addCode("(" + type.getJavaName(mainblock.getVersion()) + ") ");
+			}
 			writer.addCode("bnot(");
 			mExpression2.writeJavaCode(mainblock, writer);
 			writer.addCode(")");
@@ -778,7 +860,7 @@ public class LeekExpression extends Expression {
 				writer.addCode("-");
 				mExpression2.writeJavaCode(mainblock, writer);
 			} else {
-				writer.addCode("minus(");
+				writer.addCode("(" + type.getJavaName(mainblock.getVersion()) + ") minus(");
 				mExpression2.writeJavaCode(mainblock, writer);
 				writer.addCode(")");
 			}
@@ -880,14 +962,28 @@ public class LeekExpression extends Expression {
 			writer.addCode(")");
 			return;
 		case Operators.AS:
-			if (mExpression2 instanceof LeekType lt) {
-				if (lt.getType().accepts(mExpression1.getType()) != CastType.EQUALS) {
-					writer.addCode("(");
-					mExpression2.writeJavaCode(mainblock, writer);
-					writer.addCode(") ");
+			if (mExpression2.getType() == Type.BIG_INT) {
+				writer.addCode("BigIntegerValue.valueOf(" + writer.getAIThis() + ", ");
+				mExpression1.writeJavaCode(mainblock, writer);
+				writer.addCode(")");
+			} else if (mExpression2.getType() == Type.INT) {
+					writer.addCode("longint(");
+					mExpression1.writeJavaCode(mainblock, writer);
+					writer.addCode(")");
+			} else if (mExpression2.getType() == Type.REAL) {
+				writer.addCode("real(");
+				mExpression1.writeJavaCode(mainblock, writer);
+				writer.addCode(")");
+			} else {
+				if (mExpression2 instanceof LeekType lt) {
+					if (lt.getType().accepts(mExpression1.getType()) != CastType.EQUALS) {
+						writer.addCode("(");
+						mExpression2.writeJavaCode(mainblock, writer);
+						writer.addCode(") ");
+					}
 				}
+				mExpression1.writeJavaCode(mainblock, writer);
 			}
-			mExpression1.writeJavaCode(mainblock, writer);
 			return;
 		case Operators.IN:
 			writer.addCode("operatorIn(");
@@ -1113,8 +1209,20 @@ public class LeekExpression extends Expression {
 		} else if (mOperator == Operators.NOT || mOperator == Operators.EQUALS_EQUALS || mOperator == Operators.LESS || mOperator == Operators.MORE || mOperator == Operators.MOREEQUALS || mOperator == Operators.LESSEQUALS || mOperator == Operators.EQUALS || mOperator == Operators.AND || mOperator == Operators.OR || mOperator == Operators.XOR || mOperator == Operators.NOTEQUALS || mOperator == Operators.NOT_EQUALS_EQUALS || mOperator == Operators.INSTANCEOF || mOperator == Operators.IN) {
 			type = Type.BOOL;
 		}
-		else if (mOperator == Operators.BITAND || mOperator == Operators.BITNOT || mOperator == Operators.BITOR  || mOperator == Operators.BITXOR || mOperator == Operators.SHIFT_LEFT || mOperator == Operators.SHIFT_RIGHT || mOperator == Operators.SHIFT_UNSIGNED_RIGHT || mOperator == Operators.INTEGER_DIVISION) {
-			type = Type.INT;
+		else if (mOperator == Operators.SHIFT_LEFT || mOperator == Operators.SHIFT_RIGHT || mOperator == Operators.SHIFT_UNSIGNED_RIGHT) {
+			type = mExpression1.getType().shift(mExpression2.getType());
+		}
+		else if (mOperator == Operators.BITAND || mOperator == Operators.BITOR  || mOperator == Operators.BITXOR) {
+			type = mExpression1.getType().binop(mExpression2.getType());
+		}
+		else if (mOperator == Operators.BITNOT) {
+			if (mExpression1.getType() == Type.BIG_INT) {
+				type = Type.BIG_INT;
+			} else if (mExpression1.getType() == Type.INT) {
+				type = Type.INT;
+			} else {
+				type = Type.ANY;
+			}
 		}
 		else if (mOperator == Operators.ADD) {
 			type = mExpression1.getType().add(mExpression2.getType());
@@ -1123,13 +1231,16 @@ public class LeekExpression extends Expression {
 			type = mExpression1.getType().sub(mExpression2.getType());
 		}
 		else if (mOperator == Operators.MODULUS) {
-			type = mExpression1.getType().mul(mExpression2.getType());
+			type = mExpression1.getType().mod(mExpression2.getType());
 		}
 		else if (mOperator == Operators.MULTIPLIE) {
 			type = mExpression1.getType().mul(mExpression2.getType());
 		}
+		else if (mOperator == Operators.INTEGER_DIVISION) {
+			type = mExpression1.getType().intdiv(mExpression2.getType());
+		}
 		else if (mOperator == Operators.DIVIDE && compiler.getVersion() > 1) {
-			type = Type.REAL; // In V1, result can be null if division by 0
+			type = mExpression1.getType().div(mExpression2.getType());
 		}
 		else if (mOperator == Operators.UNARY_MINUS) {
 			type = mExpression2.getType();

--- a/src/main/java/leekscript/compiler/expression/LeekFunctionCall.java
+++ b/src/main/java/leekscript/compiler/expression/LeekFunctionCall.java
@@ -256,6 +256,9 @@ public class LeekFunctionCall extends Expression {
 				if (cvt.getClassDeclaration().getName() == "Integer") {
 					writer.addCode("0l");
 					addFinalParenthesis = false;
+				} else if (cvt.getClassDeclaration().getName() == "BigInteger") {
+					writer.addCode("new BigIntegerValue(" + writer.getAIThis() + ", 0)");
+					addFinalParenthesis = false;
 				} else if (cvt.getClassDeclaration().getName() == "Real" || cvt.getClassDeclaration().getName() == "Number") {
 					writer.addCode("0.0");
 					addFinalParenthesis = false;

--- a/src/main/java/leekscript/compiler/expression/LeekInteger.java
+++ b/src/main/java/leekscript/compiler/expression/LeekInteger.java
@@ -1,0 +1,39 @@
+package leekscript.compiler.expression;
+
+import leekscript.common.Type;
+import leekscript.compiler.JavaWriter;
+import leekscript.compiler.Token;
+import leekscript.compiler.bloc.MainLeekBlock;
+
+public class LeekInteger extends LeekNumber {
+
+	private final long value;
+
+	public LeekInteger(Token token, long value) {
+		super(token, Type.INT);
+		this.value = value;
+	}
+
+	@Override
+	public boolean isInfinity() {
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return String.valueOf(value);
+	}
+
+	@Override
+	public void writeJavaCode(MainLeekBlock mainblock, JavaWriter writer) {
+		writer.addCode(String.valueOf(value) + "l");
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof LeekInteger) {
+			return value == ((LeekInteger) o).value;
+		}
+		return false;
+	}
+}

--- a/src/main/java/leekscript/compiler/expression/LeekNumber.java
+++ b/src/main/java/leekscript/compiler/expression/LeekNumber.java
@@ -1,28 +1,19 @@
 package leekscript.compiler.expression;
 
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-import java.util.Locale;
-
 import leekscript.common.Type;
 import leekscript.compiler.Hover;
-import leekscript.compiler.JavaWriter;
 import leekscript.compiler.Location;
 import leekscript.compiler.Token;
 import leekscript.compiler.WordCompiler;
 import leekscript.compiler.bloc.MainLeekBlock;
 
-public class LeekNumber extends Expression {
+public abstract class LeekNumber extends Expression {
 
 	private final Token token;
-	private final double doubleValue;
-	private final long longValue;
 	private Type type;
 
-	public LeekNumber(Token token, double doubleValue, long longValue, Type type) {
+	public LeekNumber(Token token, Type type) {
 		this.token = token;
-		this.doubleValue = doubleValue;
-		this.longValue = longValue;
 		this.type = type;
 		this.token.setExpression(this);
 	}
@@ -37,21 +28,7 @@ public class LeekNumber extends Expression {
 		return type;
 	}
 
-	public boolean isInfinity() {
-		return doubleValue == Double.POSITIVE_INFINITY;
-	}
-
-	@Override
-	public String toString() {
-		if (type == Type.REAL) {
-			var formatter = (DecimalFormat) NumberFormat.getNumberInstance(Locale.US);
-			formatter.setMaximumFractionDigits(15);
-			formatter.setGroupingUsed(false);
-			return formatter.format(doubleValue);
-		} else {
-			return String.valueOf(longValue);
-		}
-	}
+	public abstract boolean isInfinity();
 
 	@Override
 	public boolean validExpression(WordCompiler compiler, MainLeekBlock mainblock) throws LeekExpressionException {
@@ -60,31 +37,8 @@ public class LeekNumber extends Expression {
 	}
 
 	@Override
-	public void writeJavaCode(MainLeekBlock mainblock, JavaWriter writer) {
-		if (type == Type.INT) {
-			writer.addCode(String.valueOf(longValue) + "l");
-		} else {
-			if (doubleValue == Double.POSITIVE_INFINITY) {
-				writer.addCode("Double.POSITIVE_INFINITY");
-			} else {
-				writer.addCode(String.valueOf(doubleValue));
-			}
-		}
-	}
-
-	@Override
 	public void analyze(WordCompiler compiler) {
 
-	}
-
-	public boolean equals(Object o) {
-		if (o instanceof LeekNumber) {
-			var n = (LeekNumber) o;
-			if (type != n.type) return false;
-			if (type == Type.INT) return longValue == n.longValue;
-			return doubleValue == n.doubleValue;
-		}
-		return false;
 	}
 
 	@Override

--- a/src/main/java/leekscript/compiler/expression/LeekObjectAccess.java
+++ b/src/main/java/leekscript/compiler/expression/LeekObjectAccess.java
@@ -252,7 +252,7 @@ public class LeekObjectAccess extends Expression {
 
 		if (object instanceof LeekVariable && ((LeekVariable) object).getVariableType() == VariableType.THIS) {
 			writer.addCode(field.getWord() + " = ");
-			writer.cast(mainblock, expr, type);
+			writer.compileConvert(mainblock, 0, expr, type);
 		} else if (object.getType() instanceof ClassType) {
 			object.writeJavaCode(mainblock, writer);
 			writer.addCode("." + field.getWord() + " = ");
@@ -317,156 +317,89 @@ public class LeekObjectAccess extends Expression {
 
 	@Override
 	public void compileAddEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr, Type t) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_add_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "add");
 	}
 
 	@Override
-
 	public void compileSubEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_sub_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "sub");
 	}
 
 	@Override
-
 	public void compileMulEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr, Type t) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_mul_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "mul");
 	}
 
 	@Override
-
 	public void compilePowEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr, Type t) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_pow_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "pow");
 	}
 
 	@Override
-
 	public void compileDivEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_div_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "div");
 	}
 
 	@Override
-
 	public void compileIntDivEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_intdiv_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "intdiv");
 	}
 
 	@Override
-
 	public void compileModEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_mod_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "mod");
 	}
 
 	@Override
-
 	public void compileBitOrEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_bor_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "bor");
 	}
 
 	@Override
-
 	public void compileBitAndEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_band_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "band");
 	}
 
 	@Override
-
 	public void compileBitXorEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_bxor_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "bxor");
 	}
 
 	@Override
-
 	public void compileShiftLeftEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_shl_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "shl");
 	}
 
 	@Override
-
 	public void compileShiftRightEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_shr_eq(");
-		object.writeJavaCode(mainblock, writer);
-		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
-		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
+		compileEq(mainblock, writer, expr, "shr");
 	}
 
 	@Override
-
 	public void compileShiftUnsignedRightEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
+		compileEq(mainblock, writer, expr, "ushr");
+	}
+	
+	private void compileEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr, String function) {
 		// assert (object.isLeftValue() && !object.nullable());
-
-		writer.addCode("field_ushr_eq(");
+		writer.addCode("field_" + function + "_eq(");
 		object.writeJavaCode(mainblock, writer);
 		writer.addCode(", \"" + field.getWord() + "\", ");
-		expr.writeJavaCode(mainblock, writer);
+
+		if (variable != null && variable.getType().isPrimitiveNumber() && !expr.getType().isPrimitiveNumber()) {
+			// need cast
+			if (type == Type.INT) {
+				writer.addCode("longint(");
+				expr.writeJavaCode(mainblock, writer);
+				writer.addCode(")");
+			} else if (type == Type.REAL) {
+				writer.addCode("real(");
+				expr.writeJavaCode(mainblock, writer);
+				writer.addCode(")");						
+			}
+		} else {
+			expr.writeJavaCode(mainblock, writer);
+		}
 		writer.addCode(", " + mainblock.getWordCompiler().getCurrentClassVariable() + ")");
 	}
 

--- a/src/main/java/leekscript/compiler/expression/LeekReal.java
+++ b/src/main/java/leekscript/compiler/expression/LeekReal.java
@@ -1,0 +1,50 @@
+package leekscript.compiler.expression;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+import leekscript.common.Type;
+import leekscript.compiler.JavaWriter;
+import leekscript.compiler.Token;
+import leekscript.compiler.bloc.MainLeekBlock;
+
+public class LeekReal extends LeekNumber {
+
+	private final double value;
+
+	public LeekReal(Token token, double value) {
+		super(token, Type.REAL);
+		this.value = value;
+	}
+
+	@Override
+	public boolean isInfinity() {
+		return value == Double.POSITIVE_INFINITY;
+	}
+
+	@Override
+	public String toString() {
+		var formatter = (DecimalFormat) NumberFormat.getNumberInstance(Locale.US);
+		formatter.setMaximumFractionDigits(15);
+		formatter.setGroupingUsed(false);
+		return formatter.format(value);
+	}
+
+	@Override
+	public void writeJavaCode(MainLeekBlock mainblock, JavaWriter writer) {
+		if (value == Double.POSITIVE_INFINITY) {
+			writer.addCode("Double.POSITIVE_INFINITY");
+		} else {
+			writer.addCode(String.valueOf(value));
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof LeekReal) {
+			return value == ((LeekReal) o).value;
+		}
+		return false;
+	}
+}

--- a/src/main/java/leekscript/compiler/expression/LeekVariable.java
+++ b/src/main/java/leekscript/compiler/expression/LeekVariable.java
@@ -21,7 +21,8 @@ import leekscript.common.Type;
 public class LeekVariable extends Expression {
 
 	public static enum VariableType {
-		LOCAL, GLOBAL, ARGUMENT, FIELD, STATIC_FIELD, THIS, THIS_CLASS, CLASS, SUPER, METHOD, STATIC_METHOD, SYSTEM_CONSTANT, SYSTEM_FUNCTION, FUNCTION, ITERATOR
+		LOCAL, GLOBAL, ARGUMENT, FIELD, STATIC_FIELD, THIS, THIS_CLASS, CLASS, SUPER, METHOD, STATIC_METHOD,
+		SYSTEM_CONSTANT, SYSTEM_FUNCTION, FUNCTION, ITERATOR
 	}
 
 	private final Token token;
@@ -68,14 +69,16 @@ public class LeekVariable extends Expression {
 		this.box = declaration.isCaptured();
 	}
 
-	public LeekVariable(Token token, VariableType variableType, Type type, LeekVariableDeclarationInstruction declaration) {
+	public LeekVariable(Token token, VariableType variableType, Type type,
+			LeekVariableDeclarationInstruction declaration) {
 		this(token, variableType);
 		this.declaration = declaration;
 		this.box = declaration.isCaptured();
 		this.variableType = type;
 	}
 
-	public LeekVariable(Token token, VariableType type, Type variableType, ClassDeclarationInstruction classDeclaration) {
+	public LeekVariable(Token token, VariableType type, Type variableType,
+			ClassDeclarationInstruction classDeclaration) {
 		this(token, type);
 		this.classDeclaration = classDeclaration;
 		this.variableType = variableType;
@@ -108,7 +111,8 @@ public class LeekVariable extends Expression {
 	}
 
 	public boolean isLeftValue() {
-		if (type == VariableType.CLASS || type == VariableType.THIS || type == VariableType.THIS_CLASS || type == VariableType.SUPER || type == VariableType.SYSTEM_CONSTANT) {
+		if (type == VariableType.CLASS || type == VariableType.THIS || type == VariableType.THIS_CLASS
+				|| type == VariableType.SUPER || type == VariableType.SYSTEM_CONSTANT) {
 			return false;
 		}
 		return true;
@@ -116,7 +120,8 @@ public class LeekVariable extends Expression {
 
 	@Override
 	public boolean nullable() {
-		// return type != VariableType.CLASS && type != VariableType.THIS && type != VariableType.THIS_CLASS;
+		// return type != VariableType.CLASS && type != VariableType.THIS && type !=
+		// VariableType.THIS_CLASS;
 		return false;
 	}
 
@@ -185,9 +190,8 @@ public class LeekVariable extends Expression {
 			}
 			return;
 		}
-		compiler.addError(new AnalyzeError(token, AnalyzeErrorLevel.ERROR, Error.UNKNOWN_VARIABLE_OR_FUNCTION, new String[] {
-			token.getWord()
-		}));
+		compiler.addError(new AnalyzeError(token, AnalyzeErrorLevel.ERROR, Error.UNKNOWN_VARIABLE_OR_FUNCTION,
+				new String[] { token.getWord() }));
 	}
 
 	@Override
@@ -263,7 +267,8 @@ public class LeekVariable extends Expression {
 			user_function.compileAnonymousFunction(mainblock, writer);
 		} else if (type == VariableType.SYSTEM_CONSTANT) {
 			var constant = LeekConstants.get(token.getWord());
-			if (constant.getType() == Type.INT) writer.addCode(String.valueOf(constant.getIntValue()) + "l");
+			if (constant.getType() == Type.INT)
+				writer.addCode(String.valueOf(constant.getIntValue()) + "l");
 			else if (constant.getType() == Type.REAL) {
 				if (constant == LeekConstants.NaN) {
 					writer.addCode("Double.NaN");
@@ -272,8 +277,7 @@ public class LeekVariable extends Expression {
 				} else {
 					writer.addCode(String.valueOf(constant.getValue()));
 				}
-			}
-			else writer.addCode("null");
+			} else writer.addCode("null");
 		} else if (type == VariableType.SYSTEM_FUNCTION) {
 			FunctionBlock user_function = mainblock.getUserFunction(token.getWord());
 			if (user_function != null) {
@@ -283,7 +287,8 @@ public class LeekVariable extends Expression {
 				writer.generateAnonymousSystemFunction(system_function);
 				// String namespace = LeekFunctions.getNamespace(token.getWord());
 				writer.addCode(system_function.getStandardClass() + "_" + token.getWord());
-				// writer.addCode("LeekValueManager.getFunction(" + namespace + "." + token.getWord() + ")");
+				// writer.addCode("LeekValueManager.getFunction(" + namespace + "." +
+				// token.getWord() + ")");
 			}
 		} else if (type == VariableType.GLOBAL) {
 			if (mainblock.getWordCompiler().getVersion() <= 1) {
@@ -295,6 +300,8 @@ public class LeekVariable extends Expression {
 			if (classDeclaration.internal) {
 				if (token.getWord().equals("Array") && mainblock.getVersion() <= 3) {
 					writer.addCode("legacyArrayClass");
+				} else if (token.getWord().equals("BigInteger")) {
+					writer.addCode("bigIntegerClass");
 				} else {
 					writer.addCode(token.getWord().toLowerCase() + "Class");
 				}
@@ -338,11 +345,13 @@ public class LeekVariable extends Expression {
 				writer.generateAnonymousSystemFunction(system_function);
 				// String namespace = LeekFunctions.getNamespace(token.getWord());
 				writer.addCode(system_function.getStandardClass() + "_" + token.getWord());
-				// writer.addCode("LeekValueManager.getFunction(" + namespace + "." + token.getWord() + ")");
+				// writer.addCode("LeekValueManager.getFunction(" + namespace + "." +
+				// token.getWord() + ")");
 			}
 		} else if (type == VariableType.SYSTEM_CONSTANT) {
 			var constant = LeekConstants.get(token.getWord());
-			if (constant.getType() == Type.INT) writer.addCode(String.valueOf(constant.getIntValue()) + "l");
+			if (constant.getType() == Type.INT)
+				writer.addCode(String.valueOf(constant.getIntValue()) + "l");
 			else if (constant.getType() == Type.REAL) {
 				if (constant == LeekConstants.NaN) {
 					writer.addCode("Double.NaN");
@@ -351,8 +360,7 @@ public class LeekVariable extends Expression {
 				} else {
 					writer.addCode(String.valueOf(constant.getValue()));
 				}
-			}
-			else writer.addCode("null");
+			} else writer.addCode("null");
 		} else if (type == VariableType.FUNCTION) {
 			FunctionBlock user_function = mainblock.getUserFunction(token.getWord());
 			user_function.compileAnonymousFunction(mainblock, writer);
@@ -377,7 +385,8 @@ public class LeekVariable extends Expression {
 			writer.addCode(token.getWord() + " = ");
 			writer.compileConvert(mainblock, 0, expr, variableType);
 		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".setField(\"" + token.getWord() + "\", ");
+			writer.addCode(
+					mainblock.getWordCompiler().getCurrentClassVariable() + ".setField(\"" + token.getWord() + "\", ");
 			expr.writeJavaCode(mainblock, writer);
 			writer.addCode(")");
 		} else if (mainblock.isRedefinedFunction(token.getWord())) {
@@ -388,11 +397,9 @@ public class LeekVariable extends Expression {
 			if (mainblock.getWordCompiler().getVersion() >= 2) {
 				writer.addCode("g_" + token.getWord() + " = ");
 				if (this.variable.getType() != Type.ANY && this.variable.getType() != expr.getType()) {
-					writer.addCode("(" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") (");
-				}
-				expr.writeJavaCode(mainblock, writer);
-				if (this.variable.getType() != Type.ANY && this.variable.getType() != expr.getType()) {
-					writer.addCode(")");
+					writer.compileConvert(mainblock, 0, expr, variableType);
+				} else {
+					expr.writeJavaCode(mainblock, writer);
 				}
 			} else {
 				writer.addCode("g_" + token.getWord() + ".set(");
@@ -416,12 +423,12 @@ public class LeekVariable extends Expression {
 				}
 			} else if (isBox()) {
 				// if (expr.isLeftValue()) {
-				// 	writer.addCode("u_" + token.getWord() + " = ");
-				// 	expr.compileL(mainblock, writer);
+				// writer.addCode("u_" + token.getWord() + " = ");
+				// expr.compileL(mainblock, writer);
 				// } else {
-					writer.addCode("u_" + token.getWord() + ".set(");
-					writer.compileConvert(mainblock, 0, expr, this.variableType);
-					writer.addCode(")");
+				writer.addCode("u_" + token.getWord() + ".set(");
+				writer.compileConvert(mainblock, 0, expr, this.variableType);
+				writer.addCode(")");
 				// }
 			} else {
 				writer.addCode("u_" + token.getWord() + " = ");
@@ -473,7 +480,11 @@ public class LeekVariable extends Expression {
 	@Override
 	public void compileIncrement(MainLeekBlock mainblock, JavaWriter writer) {
 		if (type == VariableType.FIELD) {
-			writer.addCode("sub(" + token.getWord() + " = add(" + token.getWord() + ", 1l), 1l)");
+			writer.addCode("sub(" + token.getWord() + " = ");
+			if (!this.variableType.isPrimitiveNumber()) {
+				writer.addCode("(" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") ");
+			}
+			writer.addCode("add(" + token.getWord() + ", 1l), 1l)");
 		} else if (type == VariableType.STATIC_FIELD) {
 			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_inc(\"" + token.getWord() + "\")");
 		} else if (type == VariableType.GLOBAL) {
@@ -482,7 +493,7 @@ public class LeekVariable extends Expression {
 			} else if (this.variableType.isPrimitiveNumber()) {
 				writer.addCode("g_" + token.getWord() + "++");
 			} else {
-				writer.addCode("sub(g_" + token.getWord() + " = add(g_" + token.getWord() + ", 1l), 1l)");
+				writer.addCode("sub(g_" + token.getWord() + " = (" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") add(g_" + token.getWord() + ", 1l), 1l)");
 			}
 		} else {
 			if (isBox()) {
@@ -490,7 +501,7 @@ public class LeekVariable extends Expression {
 			} else if (this.variableType.isPrimitiveNumber()) {
 				writer.addCode("u_" + token.getWord() + "++");
 			} else {
-				writer.addCode("sub(u_" + token.getWord() + " = add(u_" + token.getWord() + ", 1l), 1l)");
+				writer.addCode("sub(u_" + token.getWord() + " = (" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") add(u_" + token.getWord() + ", 1l), 1l)");
 			}
 		}
 	}
@@ -498,7 +509,11 @@ public class LeekVariable extends Expression {
 	@Override
 	public void compileDecrement(MainLeekBlock mainblock, JavaWriter writer) {
 		if (type == VariableType.FIELD) {
-			writer.addCode("add(" + token.getWord() + " = sub(" + token.getWord() + ", 1l), 1l)");
+			writer.addCode("add(" + token.getWord() + " = ");
+			if (!this.variableType.isPrimitiveNumber()) {
+				writer.addCode("(" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") ");
+			}
+			writer.addCode("sub(" + token.getWord() + ", 1l), 1l)");
 		} else if (type == VariableType.STATIC_FIELD) {
 			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_dec(\"" + token.getWord() + "\")");
 		} else if (type == VariableType.GLOBAL) {
@@ -507,7 +522,7 @@ public class LeekVariable extends Expression {
 			} else if (this.variableType.isPrimitiveNumber()) {
 				writer.addCode("g_" + token.getWord() + "--");
 			} else {
-				writer.addCode("add(g_" + token.getWord() + " = sub(g_" + token.getWord() + ", 1l), 1l)");
+				writer.addCode("add(g_" + token.getWord() + " = (" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") sub(g_" + token.getWord() + ", 1l), 1l)");
 			}
 		} else {
 			if (isBox()) {
@@ -515,7 +530,7 @@ public class LeekVariable extends Expression {
 			} else if (this.variableType.isPrimitiveNumber()) {
 				writer.addCode("u_" + token.getWord() + "--");
 			} else {
-				writer.addCode("add(u_" + token.getWord() + " = sub(u_" + token.getWord() + ", 1l), 1l)");
+				writer.addCode("add(u_" + token.getWord() + " = (" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") sub(u_" + token.getWord() + ", 1l), 1l)");
 			}
 		}
 	}
@@ -523,16 +538,21 @@ public class LeekVariable extends Expression {
 	@Override
 	public void compilePreIncrement(MainLeekBlock mainblock, JavaWriter writer) {
 		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = add(" + token.getWord() + ", 1l)");
+			writer.addCode(token.getWord() + " = ");
+			if (!this.variableType.isPrimitiveNumber()) {
+				writer.addCode("(" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") ");
+			}
+			writer.addCode("add(" + token.getWord() + ", 1l)");
 		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_pre_inc(\"" + token.getWord() + "\")");
+			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_pre_inc(\"" + token.getWord()
+					+ "\")");
 		} else if (type == VariableType.GLOBAL) {
 			if (isBox()) {
 				writer.addCode("g_" + token.getWord() + ".pre_increment()");
 			} else if (this.variableType.isPrimitiveNumber()) {
 				writer.addCode("++g_" + token.getWord());
 			} else {
-				writer.addCode("g_" + token.getWord() + " = add(g_" + token.getWord() + ", 1l)");
+				writer.addCode("g_" + token.getWord() + " = (" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") add(g_" + token.getWord() + ", 1l)");
 			}
 		} else {
 			if (isBox()) {
@@ -540,7 +560,7 @@ public class LeekVariable extends Expression {
 			} else if (this.variableType.isPrimitiveNumber()) {
 				writer.addCode("++u_" + token.getWord());
 			} else {
-				writer.addCode("u_" + token.getWord() + " = add(u_" + token.getWord() + ", 1l)");
+				writer.addCode("u_" + token.getWord() + " = (" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") add(u_" + token.getWord() + ", 1l)");
 			}
 		}
 	}
@@ -548,16 +568,21 @@ public class LeekVariable extends Expression {
 	@Override
 	public void compilePreDecrement(MainLeekBlock mainblock, JavaWriter writer) {
 		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = sub(" + token.getWord() + ", 1l)");
+			writer.addCode(token.getWord() + " = ");
+			if (!this.variableType.isPrimitiveNumber()) {
+				writer.addCode("(" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") ");
+			}
+			writer.addCode("sub(" + token.getWord() + ", 1l)");
 		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_pre_dec(\"" + token.getWord() + "\")");
+			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_pre_dec(\"" + token.getWord()
+					+ "\")");
 		} else if (type == VariableType.GLOBAL) {
 			if (isBox()) {
 				writer.addCode("g_" + token.getWord() + ".pre_decrement()");
 			} else if (this.variableType.isPrimitiveNumber()) {
 				writer.addCode("--g_" + token.getWord());
 			} else {
-				writer.addCode("g_" + token.getWord() + " = sub(g_" + token.getWord() + ", 1l)");
+				writer.addCode("g_" + token.getWord() + " = (" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") sub(g_" + token.getWord() + ", 1l)");
 			}
 		} else {
 			if (isBox()) {
@@ -565,7 +590,7 @@ public class LeekVariable extends Expression {
 			} else if (this.variableType.isPrimitiveNumber()) {
 				writer.addCode("--u_" + token.getWord());
 			} else {
-				writer.addCode("u_" + token.getWord() + " = sub(u_" + token.getWord() + ", 1l)");
+				writer.addCode("u_" + token.getWord() + " = (" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") sub(u_" + token.getWord() + ", 1l)");
 			}
 		}
 	}
@@ -574,539 +599,194 @@ public class LeekVariable extends Expression {
 	public void compileAddEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr, Type t) {
 		if (type == VariableType.FIELD) {
 			writer.addCode(token.getWord() + " = ");
-			if (variableType != Type.ANY) {
-				writer.addCode("(" + variableType.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
+			if (this.variable.getType() != Type.ANY) {
+				writer.addCode("((" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") ");
+				writer.addCode("add(" + token.getWord() + ", ");
+				expr.writeJavaCode(mainblock, writer);
+				writer.addCode("))");
+			} else {
+				writer.addCode("add(" + token.getWord() + ", ");
+				expr.writeJavaCode(mainblock, writer);
+				writer.addCode(")");
 			}
-			writer.addCode("add(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
 		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_add_eq(\"" + token.getWord() + "\", ");
+			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_add_eq(\""
+					+ token.getWord() + "\", ");
 			expr.writeJavaCode(mainblock, writer);
 			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".add_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isNumber() && expr.getType().isPrimitiveNumber()) {
-				writer.addCode("g_" + token.getWord() + " += ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("g_" + token.getWord() + " = add(g_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
 		} else {
+			String prefix = (type == VariableType.GLOBAL ? "g_": "u_");
 			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".add_eq(");
+				writer.addCode(prefix + token.getWord() + ".add_eq(");
 				expr.writeJavaCode(mainblock, writer);
 				writer.addCode(")");
-			} else if (this.variableType.isNumber() && expr.getType().isPrimitiveNumber()) {
-				writer.addCode("u_" + token.getWord() + " += ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("u_" + token.getWord() + " = ");
-				if (this.variableType != Type.ANY) {
-					writer.addCode("(" + this.variableType.getJavaName(mainblock.getVersion()) + ") ");
+			} else if (this.variableType.isPrimitiveNumber()) {
+				writer.addCode(prefix + token.getWord() + " += ");
+				if (expr.getType().isPrimitiveNumber()) {
+					expr.writeJavaCode(mainblock, writer);
+				} else {
+					if (this.variableType == Type.INT) {
+						writer.addCode("longint(");
+						expr.writeJavaCode(mainblock, writer);
+						writer.addCode(")");
+					} else if (this.variableType == Type.REAL) {
+						writer.addCode("real(");
+						expr.writeJavaCode(mainblock, writer);
+						writer.addCode(")");						
+					}
 				}
-				writer.addCode("add_eq(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
+			} else {
+				writer.addCode(prefix + token.getWord() + " = ");
+				if (this.variable.getType() != Type.ANY) {
+					writer.addCode("((" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") ");
+					writer.addCode("add_eq(" + prefix + token.getWord() + ", ");
+					expr.writeJavaCode(mainblock, writer);
+					writer.addCode("))");
+				} else {
+					writer.addCode("add_eq(" + prefix + token.getWord() + ", ");
+					expr.writeJavaCode(mainblock, writer);
+					writer.addCode(")");
+				}
 			}
 		}
 	}
 
 	@Override
 	public void compileSubEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = ");
-			if (variableType != Type.ANY) {
-				writer.addCode("(" + variableType.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
-			}
-			writer.addCode("sub(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_sub_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".sub_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isNumber() && expr.getType().isPrimitiveNumber()) {
-				writer.addCode("g_" + token.getWord() + " -= ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("g_" + token.getWord() + " = sub(g_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		} else {
-			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".sub_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isNumber() && expr.getType().isPrimitiveNumber()) {
-				writer.addCode("u_" + token.getWord() + " -= ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("u_" + token.getWord() + " = (" + this.variableType.getJavaPrimitiveName(mainblock.getVersion()) + ") sub(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		}
+		compileEq(mainblock, writer, expr, "sub", "-=");
 	}
 
 	@Override
 	public void compileMulEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr, Type resultType) {
-		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = ");
-			if (variableType != Type.ANY) {
-				writer.addCode("(" + variableType.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
-			}
-			writer.addCode("mul(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_mul_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".mul_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isNumber() && expr.getType().isPrimitiveNumber()) {
-				writer.addCode("g_" + token.getWord() + " *= ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("g_" + token.getWord() + " = mul(g_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		} else {
-			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".mul_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isNumber() && expr.getType().isPrimitiveNumber()) {
-				writer.addCode("u_" + token.getWord() + " *= ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("u_" + token.getWord() + " = (" + resultType.getJavaName(mainblock.getVersion()) + ") mul(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		}
+		compileEq(mainblock, writer, expr, "mul", "*=");
 	}
-
 
 	@Override
 	public void compilePowEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr, Type resultType) {
-		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = ");
-			if (variableType != Type.ANY) {
-				writer.addCode("(" + variableType.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
-			}
-			writer.addCode("pow(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_pow_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".pow_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else {
-				writer.addCode("g_" + token.getWord() + " = pow(g_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		} else {
-			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".pow_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else {
-				writer.addCode("u_" + token.getWord() + " = (" + resultType.getJavaName(mainblock.getVersion()) + ") pow(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		}
+		compileEq(mainblock, writer, expr, "pow");
 	}
 
 	@Override
 	public void compileDivEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = ");
-			if (variableType != Type.ANY) {
-				writer.addCode("(" + variableType.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
-			}
-			writer.addCode("div(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_div_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				if (mainblock.getVersion() == 1) {
-					writer.addCode("g_" + token.getWord() + ".div_eq_v1(");
-				} else {
-					writer.addCode("g_" + token.getWord() + ".div_eq(");
-				}
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else {
-				if (mainblock.getVersion() == 1) {
-					writer.addCode("g_" + token.getWord() + " = div_v1(g_" + token.getWord() + ", ");
-				} else {
-					writer.addCode("g_" + token.getWord() + " = div(g_" + token.getWord() + ", ");
-				}
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
+		if (mainblock.getVersion() == 1) {
+			compileEq(mainblock, writer, expr, "div_v1", "/=");
 		} else {
-			if (isBox()) {
-				if (mainblock.getVersion() == 1) {
-					writer.addCode("u_" + token.getWord() + ".div_eq_v1(");
-				} else {
-					writer.addCode("u_" + token.getWord() + ".div_eq(");
-				}
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else {
-				if (mainblock.getVersion() == 1) {
-					writer.addCode("u_" + token.getWord() + " = div_v1(u_" + token.getWord() + ", ");
-				} else {
-					writer.addCode("u_" + token.getWord() + " = (" + this.variableType.getJavaPrimitiveName(mainblock.getVersion()) + ") div(u_" + token.getWord() + ", ");
-				}
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
+			compileEq(mainblock, writer, expr, "div", "/=");
 		}
 	}
 
 	@Override
 	public void compileIntDivEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = ");
-			writer.addCode("intdiv(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_intdiv_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".intdiv_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else {
-				writer.addCode("g_" + token.getWord() + " = intdiv(g_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		} else {
-			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".intdiv_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-
-			} else {
-				writer.addCode("u_" + token.getWord() + " = intdiv(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		}
+		compileEq(mainblock, writer, expr, "intdiv");
 	}
 
 	@Override
 	public void compileModEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = ");
-			if (variableType != Type.ANY) {
-				writer.addCode("(" + variableType.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
-			}
-			writer.addCode("mod(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_mod_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".mod_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("g_" + token.getWord() + " %= ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("g_" + token.getWord() + " = mod(g_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		} else {
-			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".mod_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("u_" + token.getWord() + " %= ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("u_" + token.getWord() + " = mod(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		}
+		compileEq(mainblock, writer, expr, "mod", "%=");
 	}
 
 	@Override
 	public void compileBitOrEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = ");
-			if (variableType != Type.ANY) {
-				writer.addCode("(" + variableType.getJavaPrimitiveName(mainblock.getVersion()) + ") ");
-			}
-			writer.addCode("bor(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_bor_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".bor_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("g_" + token.getWord() + " |= ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("g_" + token.getWord() + " = bor(g_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		} else {
-			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".bor_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
- 				writer.addCode("u_" + token.getWord() + " |= ");
-				writer.getInt(mainblock, expr);
-			} else {
-				writer.addCode("u_" + token.getWord() + " = bor(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		}
+		compileEq(mainblock, writer, expr, "bor", "|=");
 	}
-
 
 	@Override
 	public void compileBitAndEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = band(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_band_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".band_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("g_" + token.getWord() + " &= ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("g_" + token.getWord() + " = band(g_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		} else {
-			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".band_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("u_" + token.getWord() + " &= ");
-				writer.getInt(mainblock, expr);
-			} else {
-				writer.addCode("u_" + token.getWord() + " = band(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		}
+		compileEq(mainblock, writer, expr, "band", "&=");
 	}
 
 	@Override
 	public void compileBitXorEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = bxor(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_bxor_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".bxor_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("g_" + token.getWord() + " ^= ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("g_" + token.getWord() + " = bxor(g_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		} else {
-			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".bxor_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("u_" + token.getWord() + " ^= ");
-				writer.getInt(mainblock, expr);
-			} else {
-				writer.addCode("u_" + token.getWord() + " = bxor(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		}
+		compileEq(mainblock, writer, expr, "bxor", "^=");
 	}
 
 	@Override
 	public void compileShiftLeftEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = shl(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_shl_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".shl_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("g_" + token.getWord() + " <<= ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("g_" + token.getWord() + " = shl(g_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		} else {
-			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".shl_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("u_" + token.getWord() + " <<= ");
-				writer.getInt(mainblock, expr);
-			} else {
-				writer.addCode("u_" + token.getWord() + " = shl(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		}
+		compileEq(mainblock, writer, expr, "shl", "<<=");
 	}
 
 	@Override
 	public void compileShiftRightEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
-		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = shr(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_shr_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".shr_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("g_" + token.getWord() + " >>= ");
-				expr.writeJavaCode(mainblock, writer);
-			} else {
-				writer.addCode("g_" + token.getWord() + " = shr(g_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		} else {
-			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".shr_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("u_" + token.getWord() + " >>= ");
-				writer.getInt(mainblock, expr);
-			} else {
-				writer.addCode("u_" + token.getWord() + " = shr(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			}
-		}
+		compileEq(mainblock, writer, expr, "shr", ">>=");
 	}
 
 	@Override
 	public void compileShiftUnsignedRightEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr) {
+		compileEq(mainblock, writer, expr, "ushr", ">>>=");
+	}
+
+	private void compileEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr, String function) {
+		compileEq(mainblock, writer, expr, function, null);
+	}
+	
+	/**
+	 * Wrapper to write assignment functions of type "a **= b"
+	 * */
+	private void compileEq(MainLeekBlock mainblock, JavaWriter writer, Expression expr, String function,
+			String primitiveFunction) {
 		if (type == VariableType.FIELD) {
-			writer.addCode(token.getWord() + " = ushr(" + token.getWord() + ", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.STATIC_FIELD) {
-			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_ushr_eq(\"" + token.getWord() + "\", ");
-			expr.writeJavaCode(mainblock, writer);
-			writer.addCode(")");
-		} else if (type == VariableType.GLOBAL) {
-			if (isBox()) {
-				writer.addCode("g_" + token.getWord() + ".ushr_eq(");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("g_" + token.getWord() + " >>>= ");
-				expr.writeJavaCode(mainblock, writer);
+			writer.addCode(token.getWord() + " = ");
+			if (this.variable.getType() != Type.ANY) {
+				if (this.variableType == Type.INT) {
+					writer.addCode("longint(");
+					writer.addCode(function + "(" + token.getWord() + ", ");
+					expr.writeJavaCode(mainblock, writer);
+					writer.addCode("))");
+				} else if (this.variableType == Type.REAL) {
+					writer.addCode("real(");
+					writer.addCode(function + "(" + token.getWord() + ", ");
+					expr.writeJavaCode(mainblock, writer);
+					writer.addCode("))");						
+				}
+				else {
+					writer.addCode("((" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") ");
+					writer.addCode(function + "(" + token.getWord() + ", ");
+					expr.writeJavaCode(mainblock, writer);
+					writer.addCode("))");
+				}
 			} else {
-				writer.addCode("g_" + token.getWord() + " = ushr(g_" + token.getWord() + ", ");
+				writer.addCode(function + "(" + token.getWord() + ", ");
 				expr.writeJavaCode(mainblock, writer);
 				writer.addCode(")");
 			}
+		} else if (type == VariableType.STATIC_FIELD) {
+			writer.addCode(mainblock.getWordCompiler().getCurrentClassVariable() + ".field_" + function + "_eq(\""
+					+ token.getWord() + "\", ");
+			expr.writeJavaCode(mainblock, writer);
+			writer.addCode(")");
 		} else {
+			String prefix = (type == VariableType.GLOBAL ? "g_": "u_");
 			if (isBox()) {
-				writer.addCode("u_" + token.getWord() + ".ushr_eq(");
+				writer.addCode(prefix + token.getWord() + "." + function + "_eq(");
 				expr.writeJavaCode(mainblock, writer);
 				writer.addCode(")");
-			} else if (this.variableType.isPrimitiveNumber()) {
-				writer.addCode("u_" + token.getWord() + " >>>= ");
-				writer.getInt(mainblock, expr);
+			} else if (primitiveFunction != null && this.variableType.isPrimitiveNumber()) {
+				writer.addCode(prefix + token.getWord() + " " + primitiveFunction + " ");
+				if (expr.getType().isPrimitiveNumber()) {
+					expr.writeJavaCode(mainblock, writer);
+				} else {
+					if (this.variableType == Type.INT) {
+						writer.addCode("longint(");
+						expr.writeJavaCode(mainblock, writer);
+						writer.addCode(")");
+					} else if (this.variableType == Type.REAL) {
+						writer.addCode("real(");
+						expr.writeJavaCode(mainblock, writer);
+						writer.addCode(")");						
+					}
+				}
 			} else {
-				writer.addCode("u_" + token.getWord() + " = ushr(u_" + token.getWord() + ", ");
-				expr.writeJavaCode(mainblock, writer);
-				writer.addCode(")");
+				writer.addCode(prefix + token.getWord() + " = ");
+				if (this.variable.getType() != Type.ANY) {
+					writer.addCode("((" + this.variable.getType().getJavaName(mainblock.getVersion()) + ") ");
+					writer.addCode(function + "(" + prefix + token.getWord() + ", ");
+					expr.writeJavaCode(mainblock, writer);
+					writer.addCode("))");
+				} else {
+					writer.addCode(function + "(" + prefix + token.getWord() + ", ");
+					expr.writeJavaCode(mainblock, writer);
+					writer.addCode(")");
+				}
 			}
 		}
 	}

--- a/src/main/java/leekscript/compiler/instruction/ClassDeclarationInstruction.java
+++ b/src/main/java/leekscript/compiler/instruction/ClassDeclarationInstruction.java
@@ -526,12 +526,17 @@ public class ClassDeclarationInstruction extends LeekInstruction {
 				writer.addLine("super(" + writer.getAIThis() + ");");
 			}
 		}
-		writer.addLine("increaseRAM(" + (2 * fieldVariables.size()) + ");");
+		writer.addLine("allocateRAM(this, " + (2 * fieldVariables.size()) + ");");
 		for (var field : fields.entrySet()) {
+			Expression expr = field.getValue().expression;
 			if (field.getValue().expression != null) {
 				writer.addCode(field.getKey());
 				writer.addCode(" = ");
-				field.getValue().expression.writeJavaCode(mainblock, writer);
+				if (field.getValue().getType() != Type.ANY) {
+					writer.compileConvert(mainblock, 0, expr, field.getValue().getType());
+				} else {
+					expr.writeJavaCode(mainblock, writer);
+				}
 				writer.addLine(";");
 			}
 		}
@@ -814,6 +819,7 @@ public class ClassDeclarationInstruction extends LeekInstruction {
 			switch (token.getWord()) {
 				case "Array": return "ArrayLeekValue";
 				case "Map": return "MapLeekValue";
+				case "BigInteger": return "BigIntegerValue";
 			}
 		}
 		return "u_" + token.getWord();
@@ -951,7 +957,7 @@ public class ClassDeclarationInstruction extends LeekInstruction {
 			if (field.getValue().expression != null) {
 				writer.addCode(className);
 				writer.addCode(".initField(\"" + field.getKey() + "\", ");
-				field.getValue().expression.writeJavaCode(mainblock, writer);
+				writer.compileConvert(mainblock, 0, field.getValue().expression, field.getValue().getType());
 				writer.addLine(");");
 			}
 		}

--- a/src/main/java/leekscript/compiler/instruction/LeekGlobalDeclarationInstruction.java
+++ b/src/main/java/leekscript/compiler/instruction/LeekGlobalDeclarationInstruction.java
@@ -53,13 +53,14 @@ public class LeekGlobalDeclarationInstruction extends LeekInstruction {
 	public void writeJavaCode(MainLeekBlock mainblock, JavaWriter writer) {
 		writer.addCode("if (!g_init_" + variableToken.getWord() + ") { ");
 		if (mainblock.getWordCompiler().getVersion() >= 2) {
+		if (mValue != null && mValue.getOperations() > 0) writer.addCode("ops(");
 			writer.addCode("g_" + variableToken.getWord() + " = ");
 			if (mValue != null) {
 				if (variable.getType() != Type.ANY) {
-					writer.addCode("(" + variable.getType().getJavaPrimitiveName(mainblock.getVersion()) + ") ");
+					writer.compileConvert(mainblock, 0, mValue, variable.getType());
+				} else {
+					mValue.writeJavaCode(mainblock, writer);
 				}
-				if (mValue.getOperations() > 0) writer.addCode("ops(");
-				mValue.writeJavaCode(mainblock, writer);
 				if (mValue.getOperations() > 0) writer.addCode(", " + mValue.getOperations() + ")");
 			} else {
 				writer.addCode(this.variable.getType().getDefaultValue(writer, mainblock.getVersion()));

--- a/src/main/java/leekscript/runner/LeekFunctions.java
+++ b/src/main/java/leekscript/runner/LeekFunctions.java
@@ -30,14 +30,21 @@ public class LeekFunctions {
 		method("abs", "Number", 2, true, new CallableVersion[] {
 			new CallableVersion(Type.REAL, new Type[] { Type.REAL }),
 			new CallableVersion(Type.INT, new Type[] { Type.INT }),
+			new CallableVersion(Type.BIG_INT, new Type[] { Type.BIG_INT }),
 		});
 		method("min", "Number", 2, true, new CallableVersion[] {
 			new CallableVersion(Type.REAL, new Type[] { Type.REAL, Type.REAL }),
 			new CallableVersion(Type.INT, new Type[] { Type.INT, Type.INT }),
+			new CallableVersion(Type.BIG_INT, new Type[] { Type.INT, Type.BIG_INT }),
+			new CallableVersion(Type.BIG_INT, new Type[] { Type.BIG_INT, Type.INT }),
+			new CallableVersion(Type.BIG_INT, new Type[] { Type.BIG_INT, Type.BIG_INT }),
 		});
 		method("max", "Number", 2, true, new CallableVersion[] {
 			new CallableVersion(Type.REAL, new Type[] { Type.REAL, Type.REAL }),
 			new CallableVersion(Type.INT, new Type[] { Type.INT, Type.INT }),
+			new CallableVersion(Type.BIG_INT, new Type[] { Type.INT, Type.BIG_INT }),
+			new CallableVersion(Type.BIG_INT, new Type[] { Type.BIG_INT, Type.INT }),
+			new CallableVersion(Type.BIG_INT, new Type[] { Type.BIG_INT, Type.BIG_INT }),
 		});
 		method("cos", "Number", 30, true, Type.REAL, new Type[] { Type.REAL });
 		method("sin", "Number", 30, true, Type.REAL, new Type[] { Type.REAL });
@@ -51,37 +58,77 @@ public class LeekFunctions {
 		method("ceil", "Number", 2, true, new CallableVersion[] {
 			new CallableVersion(Type.INT, new Type[] { Type.REAL }),
 			new CallableVersion(Type.INT, new Type[] { Type.INT }),
+			new CallableVersion(Type.BIG_INT, new Type[] { Type.BIG_INT }),
 		});
 		method("floor", "Number", 2, true, new CallableVersion[] {
 			new CallableVersion(Type.INT, new Type[] { Type.REAL }),
 			new CallableVersion(Type.INT, new Type[] { Type.INT }),
+			new CallableVersion(Type.BIG_INT, new Type[] { Type.BIG_INT }),
 		});
 		method("round", "Number", 2, true, new CallableVersion[] {
 			new CallableVersion(Type.INT, new Type[] { Type.REAL }),
 			new CallableVersion(Type.INT, new Type[] { Type.INT }),
+			new CallableVersion(Type.BIG_INT, new Type[] { Type.BIG_INT }),
 		});
+		
 		method("sqrt", "Number", 8, true, Type.REAL, new Type[] { Type.REAL });
 		method("cbrt", "Number", 62, true, Type.REAL, new Type[] { Type.REAL });
 		method("log", "Number", 39, true, Type.REAL, new Type[] { Type.REAL });
 		method("log2", "Number", 23, true, Type.REAL, new Type[] { Type.REAL });
 		method("log10", "Number", 23, true, Type.REAL, new Type[] { Type.REAL });
 		method("exp", "Number", 40, true, Type.REAL, new Type[] { Type.REAL });
-		method("pow", "Number", 140, true, Type.REAL, new Type[] { Type.REAL, Type.REAL });
+		method("pow", "Number", 140, true, new CallableVersion[] {
+				new CallableVersion(Type.REAL, new Type[] { Type.REAL, Type.REAL }),
+				new CallableVersion(Type.ANY, new Type[] { Type.BIG_INT, Type.INT }),
+				new CallableVersion(Type.ANY, new Type[] { Type.BIG_INT, Type.BIG_INT }),
+			});
 		method("rand", "Number", 30, true, Type.REAL, new Type[0]);
 		method("randInt", "Number", 30, true, Type.INT, new Type[] { Type.INT, Type.INT });
 		method("randFloat", "Number", 30, true, Type.REAL, new Type[] { Type.REAL, Type.REAL }).setMaxVersion(3, "randReal");
 		method("randReal", "Number", 30, true, Type.REAL, new Type[] { Type.REAL, Type.REAL });
 		method("hypot", "Number", 187, true, Type.REAL, new Type[] { Type.REAL, Type.REAL });
-		method("signum", "Number", 2, true, Type.INT, new Type[] { Type.REAL });
-		method("bitCount", "Number", 1, true, Type.INT, new Type[] { Type.INT }).setMinVersion(4);
-		method("trailingZeros", "Number", 1, true, Type.INT, new Type[] { Type.INT }).setMinVersion(4);
+		method("signum", "Number", 2, true, new CallableVersion[] {
+				new CallableVersion(Type.INT, new Type[] { Type.INT }),
+				new CallableVersion(Type.INT, new Type[] { Type.REAL }),
+				new CallableVersion(Type.INT, new Type[] { Type.BIG_INT }),
+			});
+		method("setBit", "Number", 1, true, new CallableVersion[] {
+				new CallableVersion(Type.INT, new Type[] { Type.INT, Type.INT }),
+				new CallableVersion(Type.INT, new Type[] { Type.INT, Type.INT, Type.INT }),
+				new CallableVersion(Type.INT, new Type[] { Type.INT, Type.INT, Type.BOOL }),
+				new CallableVersion(Type.BIG_INT, new Type[] { Type.BIG_INT, Type.INT }),
+				new CallableVersion(Type.BIG_INT, new Type[] { Type.BIG_INT, Type.INT, Type.INT }),
+				new CallableVersion(Type.BIG_INT, new Type[] { Type.BIG_INT, Type.INT, Type.BOOL }),
+		}).setMinVersion(4);
+		method("testBit", "Number", 1, true, new CallableVersion[] {
+				new CallableVersion(Type.BOOL, new Type[] { Type.INT, Type.INT }),
+				new CallableVersion(Type.BOOL, new Type[] { Type.BIG_INT, Type.INT }),
+		}).setMinVersion(4);
+		method("bitLength", "Number", 1, true, new CallableVersion[] {
+				new CallableVersion(Type.INT, new Type[] { Type.INT }),
+				new CallableVersion(Type.INT, new Type[] { Type.BIG_INT }),
+		}).setMinVersion(4);
+		method("bitCount", "Number", 1, true, new CallableVersion[] {
+				new CallableVersion(Type.INT, new Type[] { Type.INT }),
+				new CallableVersion(Type.INT, new Type[] { Type.BIG_INT }),
+			}).setMinVersion(4);
+		method("trailingZeros", "Number", 1, true, new CallableVersion[] {
+				new CallableVersion(Type.INT, new Type[] { Type.INT }),
+				new CallableVersion(Type.INT, new Type[] { Type.BIG_INT }),
+			}).setMinVersion(4);
 		method("leadingZeros", "Number", 1, true, Type.INT, new Type[] { Type.INT }).setMinVersion(4);
 		method("bitReverse", "Number", 1, true, Type.INT, new Type[] { Type.INT }).setMinVersion(4);
 		method("byteReverse", "Number", 1, true, Type.INT, new Type[] { Type.INT }).setMinVersion(4);
 		method("rotateLeft", "Number", 1, true, Type.INT, new Type[] { Type.INT, Type.INT }).setMinVersion(4);
 		method("rotateRight", "Number", 1, true, Type.INT, new Type[] { Type.INT, Type.INT }).setMinVersion(4);
-		method("binString", "Number", 10, true, Type.STRING, new Type[] { Type.INT }).setMinVersion(4);
-		method("hexString", "Number", 10, true, Type.STRING, new Type[] { Type.INT }).setMinVersion(4);
+		method("binString", "Number", 10, true, new CallableVersion[] {
+				new CallableVersion(Type.STRING, new Type[] { Type.INT }),
+				new CallableVersion(Type.STRING, new Type[] { Type.BIG_INT }),
+			}).setMinVersion(4);
+		method("hexString", "Number", 10, true, new CallableVersion[] {
+				new CallableVersion(Type.STRING, new Type[] { Type.INT }),
+				new CallableVersion(Type.STRING, new Type[] { Type.BIG_INT }),
+			}).setMinVersion(4);
 		method("realBits", "Number", 1, true, Type.INT, new Type[] { Type.REAL }).setMinVersion(4);
 		method("bitsToReal", "Number", 1, true, Type.REAL, new Type[] { Type.INT }).setMinVersion(4);
 		method("isFinite", "Number", 1, true, Type.BOOL, new Type[] { Type.REAL }).setMinVersion(4);

--- a/src/main/java/leekscript/runner/LeekOperations.java
+++ b/src/main/java/leekscript/runner/LeekOperations.java
@@ -44,7 +44,8 @@ public class LeekOperations {
 			if (level == 0) return value;
 
 			ai.ops(1 + o.size());
-			ai.increaseRAM(2 * o.size());
+			// used ram already in constructor
+			
 			// Call copy constructor
 			Object object = null;
 			try {

--- a/src/main/java/leekscript/runner/LeekReference.java
+++ b/src/main/java/leekscript/runner/LeekReference.java
@@ -1,0 +1,18 @@
+package leekscript.runner;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+
+public class LeekReference extends WeakReference<Object> {
+	private RamUsage ram;
+
+	public LeekReference(RamUsage ram, Object referent, ReferenceQueue<? super Object> q) {
+		super(referent, q);
+		this.ram = ram;
+	}
+	
+	public void finalizeResources(AI ai) {
+        ai.freeRAM(this, ram.getValue());
+    }
+
+}

--- a/src/main/java/leekscript/runner/LeekValueManager.java
+++ b/src/main/java/leekscript/runner/LeekValueManager.java
@@ -2,7 +2,7 @@ package leekscript.runner;
 
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
-import java.math.BigInteger;
+import leekscript.runner.values.BigIntegerValue;
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -43,7 +43,7 @@ public class LeekValueManager {
 		if (o instanceof Long) {
 			return o;
 		}
-		if (o instanceof BigInteger) {
+		if (o instanceof BigIntegerValue) {
 			ai.addSystemLog(AILog.ERROR, Error.INVALID_OPERATOR, new String[] { "jsonDecode(" + ai.export(o) + ")" });
 			return null;
 		}

--- a/src/main/java/leekscript/runner/RamUsage.java
+++ b/src/main/java/leekscript/runner/RamUsage.java
@@ -1,0 +1,21 @@
+package leekscript.runner;
+
+public class RamUsage {
+	private int value;
+
+	public RamUsage(int value) {
+		this.value = value;
+	}
+	
+	public void add(int ram) {
+		value += ram;
+	}
+
+	public void remove(int ram) {
+		value -= ram;
+	}
+	
+	public int getValue() {
+		return value;
+	}
+}

--- a/src/main/java/leekscript/runner/Wrapper.java
+++ b/src/main/java/leekscript/runner/Wrapper.java
@@ -69,19 +69,19 @@ public class Wrapper<T> {
 	}
 
 	public Object sub_eq(Object x) throws LeekRunException {
-		return variable.add_eq(x);
+		return variable.sub_eq(x);
 	}
 
 	public Object mul_eq(Object x) throws LeekRunException {
 		return variable.mul_eq(x);
 	}
 
-	public double div_eq(Object x) throws LeekRunException {
+	public Number div_eq(Object x) throws LeekRunException {
 		return variable.div_eq(x);
 	}
 
-	public Object div_eq_v1(Object x) throws LeekRunException {
-		return variable.div_eq_v1(x);
+	public Object div_v1_eq(Object x) throws LeekRunException {
+		return variable.div_v1_eq(x);
 	}
 
 	public Object mod_eq(Object x) throws LeekRunException {
@@ -92,27 +92,27 @@ public class Wrapper<T> {
 		return variable.pow_eq(x);
 	}
 
-	public long band_eq(Object x) throws LeekRunException {
+	public Number band_eq(Object x) throws LeekRunException {
 		return variable.band_eq(x);
 	}
 
-	public long bor_eq(Object x) throws LeekRunException {
+	public Number bor_eq(Object x) throws LeekRunException {
 		return variable.bor_eq(x);
 	}
 
-	public long bxor_eq(Object x) throws LeekRunException {
+	public Number bxor_eq(Object x) throws LeekRunException {
 		return variable.bxor_eq(x);
 	}
 
-	public long shl_eq(Object x) throws LeekRunException {
+	public Number shl_eq(Object x) throws LeekRunException {
 		return variable.shl_eq(x);
 	}
 
-	public long shr_eq(Object x) throws LeekRunException {
+	public Number shr_eq(Object x) throws LeekRunException {
 		return variable.shr_eq(x);
 	}
 
-	public long ushr_eq(Object x) throws LeekRunException {
+	public Number ushr_eq(Object x) throws LeekRunException {
 		return variable.ushr_eq(x);
 	}
 

--- a/src/main/java/leekscript/runner/classes/NumberClass.java
+++ b/src/main/java/leekscript/runner/classes/NumberClass.java
@@ -1,6 +1,9 @@
 package leekscript.runner.classes;
 
+import leekscript.runner.values.BigIntegerValue;
+
 import leekscript.runner.AI;
+import leekscript.runner.LeekRunException;
 
 public class NumberClass {
 
@@ -11,6 +14,10 @@ public class NumberClass {
 	public static double abs(AI ai, double x) {
 		return Math.abs(x);
 	}
+	
+	public static BigIntegerValue abs(AI ai, BigIntegerValue x) throws LeekRunException {
+		return x.abs();
+	}
 
 	public static long min(AI ai, long x, long y) {
 		return Math.min(x, y);
@@ -19,6 +26,18 @@ public class NumberClass {
 	public static double min(AI ai, double x, double y) {
 		return Math.min(x, y);
 	}
+	
+	public static BigIntegerValue min(AI ai, BigIntegerValue x, BigIntegerValue y) throws LeekRunException {
+		return x.min(y);
+	}
+	
+	public static BigIntegerValue min(AI ai, BigIntegerValue x, long y) throws LeekRunException {
+		return x.min(BigIntegerValue.valueOf(ai, y));
+	}
+	
+	public static BigIntegerValue min(AI ai, long x, BigIntegerValue y) throws LeekRunException {
+		return BigIntegerValue.valueOf(ai, x).min(y);
+	}
 
 	public static long max(AI ai, long x, long y) {
 		return Math.max(x, y);
@@ -26,6 +45,18 @@ public class NumberClass {
 
 	public static double max(AI ai, double x, double y) {
 		return Math.max(x, y);
+	}
+	
+	public static BigIntegerValue max(AI ai, BigIntegerValue x, BigIntegerValue y) throws LeekRunException {
+		return x.max(y);
+	}
+	
+	public static BigIntegerValue max(AI ai, BigIntegerValue x, long y) throws LeekRunException {
+		return x.max(BigIntegerValue.valueOf(ai, y));
+	}
+	
+	public static BigIntegerValue max(AI ai, long x, BigIntegerValue y) throws LeekRunException {
+		return BigIntegerValue.valueOf(ai, x).max(y);
 	}
 
 	public static double cos(AI ai, double x) {
@@ -63,8 +94,12 @@ public class NumberClass {
 	public static double toDegrees(AI ai, double x) {
 		return x * 180 / Math.PI;
 	}
-
+	
 	public static long ceil(AI ai, long x) {
+		return x;
+	}
+
+	public static BigIntegerValue ceil(AI ai, BigIntegerValue x) {
 		return x;
 	}
 
@@ -76,11 +111,19 @@ public class NumberClass {
 		return x;
 	}
 
+	public static BigIntegerValue floor(AI ai, BigIntegerValue x) {
+		return x;
+	}
+
 	public static long floor(AI ai, double x) {
 		return (long) Math.floor(x);
 	}
 
 	public static long round(AI ai, long x) {
+		return x;
+	}
+
+	public static BigIntegerValue round(AI ai, BigIntegerValue x) {
 		return x;
 	}
 
@@ -120,6 +163,14 @@ public class NumberClass {
 		return Math.pow(x, y);
 	}
 
+	public static Number pow(AI ai, BigIntegerValue x, BigIntegerValue y) throws LeekRunException {
+		return ai.pow(x, y);
+	}
+	
+	public static Number pow(AI ai, BigIntegerValue x, long y) throws LeekRunException {
+		return ai.pow(x, y);
+	}
+	
 	public static double rand(AI ai) {
 		return ai.getRandom().getDouble();
 	}
@@ -145,21 +196,77 @@ public class NumberClass {
 	public static double hypot(AI ai, double x, double y) {
 		return Math.hypot(x, y);
 	}
-
+	
 	public static long signum(AI ai, double x) {
 		return (long) Math.signum(x);
 	}
 
+	public static long signum(AI ai, BigIntegerValue x) {
+		return (long) x.signum();
+	}
+	
 	public static long bitCount(AI ai, long x) {
 		return Long.bitCount(x);
 	}
 
+	public static long bitCount(AI ai, BigIntegerValue x) {
+		return (long) x.bitCount();
+	}
+	
 	public static long trailingZeros(AI ai, long x) {
 		return Long.numberOfTrailingZeros(x);
 	}
 
+	public static long trailingZeros(AI ai, BigIntegerValue x) {
+		return (long) x.getLowestSetBit();
+	}
+	
 	public static long leadingZeros(AI ai, long x) {
 		return Long.numberOfLeadingZeros(x);
+	}
+	
+	public static long bitLength(AI ai, long x) {
+		return 64 - Long.numberOfLeadingZeros(x);
+	}
+
+	public static long bitLength(AI ai, BigIntegerValue x) {
+		return x.bitLength();
+	}
+	
+	public static long setBit(AI ai, long x, long pos, boolean val) {
+		if (val) {
+			return x | (1 << pos);
+		} else {
+			return x & ~(1 << pos);
+		}
+	}
+	
+	public static long setBit(AI ai, long x, long pos, long val) {
+		return setBit(ai, x, pos, val != 0);
+	}
+	
+	public static long setBit(AI ai, long x, long pos) {
+		return setBit(ai, x, pos, true);
+	}
+
+	public static BigIntegerValue setBit(AI ai, BigIntegerValue x, long pos, boolean val) throws LeekRunException {
+		return x.setBit((int) pos, val);
+	}
+	
+	public static BigIntegerValue setBit(AI ai, BigIntegerValue x, long pos, long val) throws LeekRunException {
+		return x.setBit((int) pos, val != 0);
+	}
+	
+	public static BigIntegerValue setBit(AI ai, BigIntegerValue x, long pos) throws LeekRunException {
+		return x.setBit((int) pos, true);
+	}
+	
+	public static boolean testBit(AI ai, long x, long pos) {
+		return (x & (1 << pos)) != 0;
+	}
+	
+	public static boolean testBit(AI ai, BigIntegerValue x, long pos) {
+		return x.testBit((int) pos);
 	}
 
 	public static long bitReverse(AI ai, long x) {
@@ -177,13 +284,21 @@ public class NumberClass {
 	public static long rotateRight(AI ai, long x, long y) {
 		return Long.rotateRight(x, (int) y);
 	}
-
+	
 	public static String binString(AI ai, long x) {
 		return Long.toBinaryString(x);
 	}
 
+	public static String binString(AI ai, BigIntegerValue x) throws LeekRunException {
+		return x.toString(2);
+	}
+	
 	public static String hexString(AI ai, long x) {
 		return Long.toHexString(x);
+	}
+
+	public static String hexString(AI ai, BigIntegerValue x) throws LeekRunException {
+		return x.toString(16);
 	}
 
 	public static long realBits(AI ai, double x) {

--- a/src/main/java/leekscript/runner/classes/ValueClass.java
+++ b/src/main/java/leekscript/runner/classes/ValueClass.java
@@ -4,6 +4,7 @@ import leekscript.runner.AI;
 import leekscript.runner.LeekOperations;
 import leekscript.runner.LeekRunException;
 import leekscript.runner.LeekValueManager;
+import leekscript.runner.values.BigIntegerValue;
 
 public class ValueClass {
 
@@ -30,7 +31,14 @@ public class ValueClass {
 				if (s.contains(".")) {
 					return Double.parseDouble(s);
 				} else {
-					return Long.parseLong(s);
+					try {
+						return Long.parseLong(s);
+					} catch (Exception e) { 
+						if (s.endsWith("L")) {
+							s = s.substring(0, s.length() - 1);
+						}
+						return BigIntegerValue.valueOf(ai, s);
+					}
 				}
 			} catch (Exception e) {}
 		}

--- a/src/main/java/leekscript/runner/values/ArrayLeekValue.java
+++ b/src/main/java/leekscript/runner/values/ArrayLeekValue.java
@@ -19,6 +19,7 @@ import leekscript.runner.LeekOperations;
 import leekscript.runner.LeekRunException;
 import leekscript.runner.LeekValueComparator;
 import leekscript.runner.LeekValueManager;
+import leekscript.runner.RamUsage;
 import leekscript.common.Error;
 
 public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLeekValue {
@@ -105,16 +106,23 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 
 	private final AI ai;
 	public final int id;
+	private RamUsage ram;
 
 	public ArrayLeekValue(AI ai) {
 		this.ai = ai;
 		this.id = ai.getNextObjectID();
+		try {
+			this.ram = ai.allocateRAM(this, 0, false);
+		} catch (LeekRunException e) {}
 	}
 
 	public ArrayLeekValue(AI ai, int capacity) {
 		super(Math.min(MAX_SIZE, capacity));
 		this.ai = ai;
 		this.id = ai.getNextObjectID();
+		try {
+			this.ram = ai.allocateRAM(this, 0, false);
+		} catch (LeekRunException e) {}
 	}
 
 	public ArrayLeekValue(AI ai, Object values[]) throws LeekRunException {
@@ -123,14 +131,14 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		for (var value : values) {
 			add(value);
 		}
-		ai.increaseRAM(values.length);
+		this.ram = ai.allocateRAM(this, values.length);
 	}
 
 	public ArrayLeekValue(AI ai, List<Object> values) throws LeekRunException {
 		super(values);
 		this.ai = ai;
 		this.id = ai.getNextObjectID();
-		ai.increaseRAM(values.size());
+		this.ram = ai.allocateRAM(this, values.size());
 	}
 
 	public ArrayLeekValue(AI ai, ArrayLeekValue array) throws LeekRunException {
@@ -140,7 +148,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 	public ArrayLeekValue(AI ai, ArrayLeekValue array, int level) throws LeekRunException {
 		this.ai = ai;
 		this.id = ai.getNextObjectID();
-		ai.increaseRAM(array.size());
+		this.ram = ai.allocateRAM(this, array.size());
 		for (var value : array) {
 			if (level == 1) {
 				add(value);
@@ -308,7 +316,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		}
 	}
 
-	public long put_intdiv_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_intdiv_eq(AI ai, Object key, Object value) throws LeekRunException {
 		ai.opsNoCheck(ArrayLeekValue.WRITE_OPERATIONS);
 		int i = (int) ai.integer(key);
 		if (i < 0) i += size();
@@ -336,7 +344,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		}
 	}
 
-	public long put_bor_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_bor_eq(AI ai, Object key, Object value) throws LeekRunException {
 		ai.opsNoCheck(ArrayLeekValue.WRITE_OPERATIONS);
 		int i = (int) ai.integer(key);
 		if (i < 0) i += size();
@@ -350,7 +358,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		}
 	}
 
-	public long put_band_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_band_eq(AI ai, Object key, Object value) throws LeekRunException {
 		ai.opsNoCheck(ArrayLeekValue.WRITE_OPERATIONS);
 		int i = (int) ai.integer(key);
 		if (i < 0) i += size();
@@ -364,7 +372,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		}
 	}
 
-	public long put_bxor_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_bxor_eq(AI ai, Object key, Object value) throws LeekRunException {
 		ai.opsNoCheck(ArrayLeekValue.WRITE_OPERATIONS);
 		int i = (int) ai.integer(key);
 		if (i < 0) i += size();
@@ -378,7 +386,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		}
 	}
 
-	public long put_shl_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_shl_eq(AI ai, Object key, Object value) throws LeekRunException {
 		ai.opsNoCheck(ArrayLeekValue.WRITE_OPERATIONS);
 		int i = (int) ai.integer(key);
 		if (i < 0) i += size();
@@ -392,7 +400,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		}
 	}
 
-	public long put_shr_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_shr_eq(AI ai, Object key, Object value) throws LeekRunException {
 		ai.opsNoCheck(ArrayLeekValue.WRITE_OPERATIONS);
 		int i = (int) ai.integer(key);
 		if (i < 0) i += size();
@@ -406,7 +414,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		}
 	}
 
-	public long put_ushr_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_ushr_eq(AI ai, Object key, Object value) throws LeekRunException {
 		ai.opsNoCheck(ArrayLeekValue.WRITE_OPERATIONS);
 		int i = (int) ai.integer(key);
 		if (i < 0) i += size();
@@ -586,7 +594,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		ai.ops(1 + Math.max(0, numMoved));
 		try {
 			var result = remove((int) key);
-			ai.decreaseRAM(1);
+			ai.decreaseRAM(ram, 1);
 			return result;
 		} catch (IndexOutOfBoundsException e) {
 			wrongIndexError(ai, (int) key);
@@ -670,7 +678,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 	public Object removeElement(AI ai, Object value) throws LeekRunException {
 		ai.ops(1 + size());
 		if (remove(value)) {
-			ai.decreaseRAM(1);
+			ai.decreaseRAM(ram, 1);
 		}
 		return null;
 	}
@@ -684,19 +692,19 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 	 */
 	@Override
 	public Object push(AI ai, Object value) throws LeekRunException {
- 		ai.increaseRAM(1);
+ 		ai.increaseRAM(ram, 1);
 		add(value);
 		return null;
 	}
 
 	public Object pushNoClone(AI ai, Object value) throws LeekRunException {
-		ai.increaseRAM(1);
+		ai.increaseRAM(ram, 1);
 		add(value);
 		return null;
 	}
 
 	public Object pushAll(AI ai, ArrayLeekValue other) throws LeekRunException {
-		ai.increaseRAM(other.size());
+		ai.increaseRAM(ram, other.size());
 		ai.ops(1 + other.size());
 		addAll(other);
 		return null;
@@ -710,7 +718,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 	 * @throws LeekRunException
 	 */
 	public Object unshift(AI ai, Object value) throws LeekRunException {
-		ai.increaseRAM(1);
+		ai.increaseRAM(ram, 1);
 		ai.ops(1 + size());
 		add(0, value);
 		return null;
@@ -722,7 +730,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 			int shifted = size() - (int) position;
 			ai.ops(1 + Math.max(0, shifted));
 			add((int) position, value);
-			ai.increaseRAM(1);
+			ai.increaseRAM(ram, 1);
 		} catch (IndexOutOfBoundsException e) {
 			wrongIndexError(ai, (int) position);
 		}
@@ -737,7 +745,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		ai.ops(1, Math.max(0, (int) size));
 		if (size >= size()) { // Agrandissement
 			var to_add = (int) size - size();
-			ai.increaseRAM(to_add);
+			ai.increaseRAM(ram, to_add);
 			Collections.fill(this, value);
 			ensureCapacity((int) size);
 			for (int i = 0; i < to_add; ++i) {
@@ -803,7 +811,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		for (int i = 0; i < size(); ++i) {
 			result.add(function.run(ai, null, get(i), (long) i, this));
 		}
-		ai.increaseRAM(size());
+		ai.increaseRAM(ram, size());
 		return result;
 	}
 
@@ -853,7 +861,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 				result.add(get(i));
 			}
 		}
-		ai.increaseRAM(size);
+		ai.increaseRAM(ram, size);
 		assert(size == result.size());
 		return result;
 	}
@@ -901,7 +909,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 				r2.add(v);
 			}
 		}
-		ai.increaseRAM(size());
+		ai.increaseRAM(ram, size());
 		return new ArrayLeekValue(ai, new Object[] { r1, r2 });
 	}
 
@@ -935,7 +943,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 				result.add(v);
 			}
 		}
-		ai.increaseRAM(result.size());
+		ai.increaseRAM(ram, result.size());
 		return result;
 	}
 
@@ -969,7 +977,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		ai.ops(1 + size());
 		var sizeBefore = size();
 		removeIf(v -> value == null ? v == value : value.equals(v));
-		ai.decreaseRAM(sizeBefore - size());
+		ai.decreaseRAM(ram, sizeBefore - size());
 		return null;
 	}
 
@@ -979,7 +987,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		for (var value : this) {
 			frequencies.merge(value, 1l, (x, y) -> (Long) x + (Long) y);
 		}
-		ai.increaseRAM(frequencies.size());
+		ai.increaseRAM(ram, frequencies.size());
 		return frequencies;
 	}
 
@@ -1015,7 +1023,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 		result.shuffle(ai);
 		var finalCount = Math.max(0, Math.min((int) count, size()));
 		result.removeRange(finalCount, size());
-		ai.decreaseRAM(size() - finalCount);
+		ai.decreaseRAM(ram, size() - finalCount);
 		return result;
 	}
 
@@ -1036,7 +1044,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 			wrongIndexError(ai, 0);
 			return null;
 		}
-		ai.decreaseRAM(1);
+		ai.decreaseRAM(ram, 1);
 		return remove(size() - 1);
 	}
 
@@ -1046,7 +1054,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 			wrongIndexError(ai, 0);
 			return null;
 		}
-		ai.decreaseRAM(1);
+		ai.decreaseRAM(ram, 1);
 		return remove(0);
 	}
 
@@ -1058,7 +1066,7 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 	}
 
 	public ArrayLeekValue arrayClear(AI ai) {
-		ai.decreaseRAM(size());
+		ai.decreaseRAM(ram, size());
 		clear();
 		return this;
 	}
@@ -1110,13 +1118,6 @@ public class ArrayLeekValue extends ArrayList<Object> implements GenericArrayLee
 				return false;
 		}
 		return true;
-	}
-
-	@Override
-	@SuppressWarnings("deprecated")
-	protected void finalize() throws Throwable {
-		super.finalize();
-		ai.decreaseRAM(size());
 	}
 
 	@Override

--- a/src/main/java/leekscript/runner/values/BigIntegerValue.java
+++ b/src/main/java/leekscript/runner/values/BigIntegerValue.java
@@ -1,0 +1,301 @@
+package leekscript.runner.values;
+
+import java.math.BigInteger;
+import java.util.Set;
+
+import leekscript.AILog;
+import leekscript.runner.AI;
+import leekscript.runner.LeekRunException;
+
+/**
+ * Represents an integer number with size limited only by memory and operations
+ * cost. Current implementation is a wrapper on BigInteger. It allows easy swap
+ * for other versions. Untested mutable version to be considered (although it does not have built-in processor optimizations) :
+ * https://github.com/bwakell/Huldra/blob/master/src/main/java/org/huldra/math/BigInt.java
+ * 
+ * @see BigInteger
+ */
+public class BigIntegerValue extends Number implements LeekValue {
+
+	private final BigInteger value;
+	private final AI ai;
+	
+	private final static int STRING_CROP_LIMIT = 10; // number of digits to keep at the beginning and the end when converting to string
+	private final static BigInteger STRING_CROP_VALUE = BigInteger.TEN.pow(STRING_CROP_LIMIT);
+	private final static double BASE_FACTOR = Math.log10(2); // used to convert from base 2 to 10
+	private final static double BIT_LIMIT = STRING_CROP_LIMIT * 2 / BASE_FACTOR; // number of bits (base 2) corresponding to crop limit (base 10)
+
+	public BigIntegerValue(AI ai, String val, int radix) throws LeekRunException {
+		this.ai = ai;
+		this.value = new BigInteger(val, radix);
+		ops(4);
+		int ram = value.bitLength() / 64;
+		ai.allocateRAM(this, ram);
+	}
+
+	public BigIntegerValue(AI ai, String val) throws LeekRunException {
+		this.ai = ai;
+		this.value = new BigInteger(val);
+		ops(4);
+		int ram = value.bitLength() / 64;
+		ai.allocateRAM(this, ram);
+	}
+
+	public BigIntegerValue(AI ai, double val) throws LeekRunException {
+		this.ai = ai;
+		this.value = BigInteger.valueOf((long) val);
+		ops(4);
+		int ram = value.bitLength() / 64;
+		ai.allocateRAM(this, ram);
+	}
+
+	public BigIntegerValue(AI ai, long val) throws LeekRunException {
+		this.ai = ai;
+		this.value = BigInteger.valueOf(val);
+		ops(4);
+		int ram = value.bitLength() / 64;
+		ai.allocateRAM(this, ram);
+	}
+
+	public BigIntegerValue(AI ai, BigInteger val) throws LeekRunException {
+		this.ai = ai;
+		this.value = val;
+		ops(4);
+		int ram = value.bitLength() / 64;
+		ai.allocateRAM(this, ram);
+	}
+
+	// benchmarks :
+	// nothing : 20s
+	// finalize : 60s
+	// phantomRef : 25s
+	// cleaner : 40s
+	// cleaner + autocloseable : 45s
+	// weak reference : 25s
+
+	public BigIntegerValue add(BigIntegerValue val) throws LeekRunException {
+		ops();
+		val.ops();
+		return new BigIntegerValue(ai, value.add(val.value));
+	}
+
+	public BigIntegerValue subtract(BigIntegerValue val) throws LeekRunException {
+		ops();
+		val.ops();
+		return new BigIntegerValue(ai, value.subtract(val.value));
+	}
+
+	public BigIntegerValue multiply(BigIntegerValue val) throws LeekRunException {
+		if (value.bitLength() < 5000) {
+			ops(value.bitLength() / 100);
+		} else {
+			ops(value.bitLength() / 50);
+		}
+
+		if (val.value.bitLength() < 5000) {
+			val.ops(val.value.bitLength() / 100);
+		} else {
+			val.ops(val.value.bitLength() / 50);
+		}
+		return new BigIntegerValue(ai, value.multiply(val.value));
+	}
+
+	public BigIntegerValue divide(BigIntegerValue val) throws LeekRunException {
+		ops(15);
+		val.ops();
+		return new BigIntegerValue(ai, value.divide(val.value));
+	}
+
+	public BigIntegerValue pow(int exponent) throws LeekRunException {
+		ops(value.bitLength() / 2000 * exponent);
+		return new BigIntegerValue(ai, value.pow(exponent));
+	}
+
+	public BigIntegerValue abs() throws LeekRunException {
+		return new BigIntegerValue(ai, value.abs());
+	}
+
+	public BigIntegerValue negate() throws LeekRunException {
+		return new BigIntegerValue(ai, value.negate());
+	}
+
+	public BigIntegerValue mod(BigIntegerValue m) throws LeekRunException {
+		ops(value.bitLength() / 50);
+		m.ops();
+		return new BigIntegerValue(ai, value.mod(m.value));
+	}
+
+	public BigIntegerValue shiftLeft(int n) throws LeekRunException {
+		binaryShiftOps(n);
+		return new BigIntegerValue(ai, value.shiftLeft(n));
+	}
+
+	public BigIntegerValue shiftRight(int n) throws LeekRunException {
+		binaryShiftOps(n);
+		return new BigIntegerValue(ai, value.shiftRight(n));
+	}
+
+	public BigIntegerValue and(BigIntegerValue val) throws LeekRunException {
+		ops(value.bitLength() / 128);
+		val.ops(val.value.bitLength() / 128);
+		return new BigIntegerValue(ai, value.and(val.value));
+	}
+
+	public BigIntegerValue or(BigIntegerValue val) throws LeekRunException {
+		ops(value.bitLength() / 512);
+		val.ops(val.value.bitLength() / 512);
+		return new BigIntegerValue(ai, value.or(val.value));
+	}
+
+	public BigIntegerValue xor(BigIntegerValue val) throws LeekRunException {
+		ops(value.bitLength() / 256);
+		val.ops(val.value.bitLength() / 256);
+		return new BigIntegerValue(ai, value.xor(val.value));
+	}
+
+	public BigIntegerValue not() throws LeekRunException {
+		ops(value.bitLength() / 256);
+		return new BigIntegerValue(ai, value.not());
+	}
+
+	public BigIntegerValue setBit(int n, boolean val) throws LeekRunException {
+		if (val) {
+			return new BigIntegerValue(ai, value.setBit(n));
+		} else {
+			return new BigIntegerValue(ai, value.clearBit(n));
+		}
+	}
+
+	public boolean testBit(int n) {
+		return value.testBit(n);
+	}
+
+	public BigIntegerValue min(BigIntegerValue val) throws LeekRunException {
+		return new BigIntegerValue(ai, value.min(val.value));
+	}
+
+	public BigIntegerValue max(BigIntegerValue val) throws LeekRunException {
+		return new BigIntegerValue(ai, value.max(val.value));
+	}
+
+	public static BigIntegerValue valueOf(AI ai, String val) throws LeekRunException {
+		return new BigIntegerValue(ai, val);
+	}
+
+	public static BigIntegerValue valueOf(AI ai, double val) throws LeekRunException {
+		return new BigIntegerValue(ai, val);
+	}
+
+	public static BigIntegerValue valueOf(AI ai, long val) throws LeekRunException {
+		return new BigIntegerValue(ai, val);
+	}
+
+	public static BigIntegerValue valueOf(AI ai, BigInteger val) throws LeekRunException {
+		return new BigIntegerValue(ai, val);
+	}
+
+	public static BigIntegerValue valueOf(AI ai, BigIntegerValue val) {
+		return val; // BigInteger is not mutable so this is safe
+	}
+
+	public static BigIntegerValue valueOf(AI ai, Object val) throws LeekRunException {
+		if (val instanceof Double)
+			return new BigIntegerValue(ai, (Double) val);
+		if (val instanceof Long)
+			return new BigIntegerValue(ai, (Long) val);
+		if (val instanceof BigIntegerValue)
+			return (BigIntegerValue) val;
+		if (val instanceof String)
+			return new BigIntegerValue(ai, (String) val);
+		ai.getLogs().addLog(AILog.ERROR, "Cannot cast \"" + val.toString() + "\" to BigInteger");
+		return new BigIntegerValue(ai, 0);
+	}
+
+	public int signum() {
+		return value.signum();
+	}
+
+	public long bitLength() {
+		return value.bitLength();
+	}
+
+	public long bitCount() {
+		return value.bitCount();
+	}
+
+	public long getLowestSetBit() {
+		return value.getLowestSetBit();
+	}
+
+	public int compareTo(BigIntegerValue y) {
+		return value.compareTo(y.value);
+	}
+
+	@Override
+	public int intValue() {
+		return value.intValue();
+	}
+
+	@Override
+	public long longValue() {
+		return value.longValue();
+	}
+
+	@Override
+	public float floatValue() {
+		return value.floatValue();
+	}
+
+	@Override
+	public double doubleValue() {
+		return value.doubleValue();
+	}
+
+	public boolean isZero() {
+		return value.equals(BigInteger.ZERO);
+	}
+
+	public String toString() {
+		ai.opsNoCheck(10);
+		if (value.bitLength() <= BIT_LIMIT) {
+			return value.toString();
+		} else {
+			ai.opsNoCheck(100);
+			// print only first and last digits to avoid overflow and slow full String response time
+			int digitLength = (int) Math.floor(value.bitLength() * BASE_FACTOR);
+			String firstDigits = value.divide(BigInteger.TEN.pow(digitLength - STRING_CROP_LIMIT)).toString()
+					.substring(0, STRING_CROP_LIMIT - Math.min(0, value.signum()));
+			ai.opsNoCheck(value.bitLength() / 128);
+			return firstDigits + "..." + String.format("%0" + STRING_CROP_LIMIT + "d", value.abs().mod(STRING_CROP_VALUE));
+		}
+	}
+
+	public String toString(int i) throws LeekRunException {
+		ops(2 + (int) Math.pow(value.bitLength(), 2) / 400 / i);
+		return value.toString(i);
+	}
+
+	@Override
+	public String string(AI ai, Set<Object> visited) throws LeekRunException {
+		return this.toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return obj instanceof BigIntegerValue && value.equals(((BigIntegerValue) obj).value);
+	}
+
+	private void binaryShiftOps(int n) throws LeekRunException {
+		ops(n < 4000 ? 1 : n / 2000);
+	}
+
+	private void ops() throws LeekRunException {
+		ops(1);
+	}
+
+	private void ops(int nb) throws LeekRunException {
+		int size = (int) (value.bitLength() / 1000);
+		ai.ops(nb + size);
+	}
+
+}

--- a/src/main/java/leekscript/runner/values/Box.java
+++ b/src/main/java/leekscript/runner/values/Box.java
@@ -1,11 +1,14 @@
 package leekscript.runner.values;
 
+import java.math.BigInteger;
+
 import leekscript.AILog;
+import leekscript.common.Error;
+import leekscript.common.Type;
 import leekscript.runner.AI;
 import leekscript.runner.LeekOperations;
 import leekscript.runner.LeekRunException;
 import leekscript.runner.LeekValueManager;
-import leekscript.common.Error;
 
 public class Box<T> {
 
@@ -81,6 +84,11 @@ public class Box<T> {
 			mValue = value + 1;
 			return (T) value;
 		}
+		if (mValue instanceof BigIntegerValue) {
+			var value = (BigIntegerValue) mValue;
+			mValue = value.add(new BigIntegerValue(mUAI, BigInteger.ONE));
+			return (T) value;
+		}
 		if (mValue instanceof Double) {
 			var value = (Double) mValue;
 			mValue = value + 1;
@@ -96,6 +104,11 @@ public class Box<T> {
 			mValue = value - 1;
 			return (T) value;
 		}
+		if (mValue instanceof BigIntegerValue) {
+			var value = (BigIntegerValue) mValue;
+			mValue = value.subtract(new BigIntegerValue(mUAI, BigInteger.ONE));
+			return (T) value;
+		}
 		if (mValue instanceof Double) {
 			var value = (Double) mValue;
 			mValue = value - 1;
@@ -109,6 +122,9 @@ public class Box<T> {
 		if (mValue instanceof Long) {
 			return (T) (mValue = (Long) mValue + 1);
 		}
+		if (mValue instanceof BigIntegerValue) {
+			return (T) (mValue = ((BigIntegerValue) mValue).add(new BigIntegerValue(mUAI, BigInteger.ONE)));
+		}
 		if (mValue instanceof Double) {
 			return (T) (mValue = (Double) mValue + 1);
 		}
@@ -119,6 +135,9 @@ public class Box<T> {
 	public T pre_decrement() throws LeekRunException {
 		if (mValue instanceof Long) {
 			return (T) (mValue = (Long) mValue - 1);
+		}
+		if (mValue instanceof BigIntegerValue) {
+			return (T) (mValue = ((BigIntegerValue) mValue).subtract(new BigIntegerValue(mUAI, BigInteger.ONE)));
 		}
 		if (mValue instanceof Double) {
 			return (T) (mValue = (Double) mValue - 1);
@@ -137,6 +156,9 @@ public class Box<T> {
 		if (mValue instanceof Double) {
 			return -(Double) mValue;
 		}
+		if (mValue instanceof BigIntegerValue) {
+			return ((BigIntegerValue) mValue).negate();
+		}
 		return -mUAI.longint(mValue);
 	}
 
@@ -144,59 +166,84 @@ public class Box<T> {
 		if (mValue instanceof LegacyArrayLeekValue && !(val instanceof String)) {
 			return mValue = mUAI.add_eq(mValue, val);
 		}
-		return mValue = mUAI.add(mValue, val);
+		Object ret = mUAI.add(mValue, val);
+		return apply_eq(ret);
 	}
 
 	public Object sub_eq(Object val) throws LeekRunException {
-		return mValue = mUAI.sub(mValue, val);
+		Object ret = mUAI.sub(mValue, val);
+		return apply_eq(ret);
 	}
 
 	public Object mul_eq(Object val) throws LeekRunException {
-		return mValue = mUAI.mul(mValue, val);
+		Object ret = mUAI.mul(mValue, val);
+		return apply_eq(ret);
 	}
 
 	public Object pow_eq(Object val) throws LeekRunException {
-		return mValue = mUAI.pow(mValue, val);
+		Object ret = mUAI.pow(mValue, val);
+		if (mUAI.getVersion() < 4) return mValue = ret;
+		return apply_eq(ret);
 	}
 
-	public long band_eq(Object val) throws LeekRunException {
-		return (long) (mValue = mUAI.band(mValue, val));
+	public Number band_eq(Object val) throws LeekRunException {
+		Number ret = mUAI.band(mValue, val);
+		return (Number) apply_eq(ret);
 	}
 
-	public long bor_eq(Object val) throws LeekRunException {
-		return (long) (mValue = mUAI.bor(mValue, val));
+	public Number bor_eq(Object val) throws LeekRunException {
+		Number ret = mUAI.bor(mValue, val);
+		return (Number) apply_eq(ret);
 	}
 
-	public long bxor_eq(Object val) throws LeekRunException {
-		return (long) (mValue = mUAI.bxor(mValue, val));
+	public Number bxor_eq(Object val) throws LeekRunException {
+		Number ret = mUAI.bxor(mValue, val);
+		return (Number) apply_eq(ret);
 	}
 
-	public long shl_eq(Object val) throws LeekRunException {
-		return (long) (mValue = mUAI.shl(mValue, val));
+	public Number shl_eq(Object val) throws LeekRunException {
+		Number ret = mUAI.shl(mValue, val);
+		return (Number) apply_eq(ret);
 	}
 
-	public long shr_eq(Object val) throws LeekRunException {
-		return (long) (mValue = mUAI.shr(mValue, val));
+	public Number shr_eq(Object val) throws LeekRunException {
+		Number ret = mUAI.shr(mValue, val);
+		return (Number) apply_eq(ret);
 	}
 
-	public long ushr_eq(Object val) throws LeekRunException {
-		return (long) (mValue = mUAI.ushr(mValue, val));
+	public Number ushr_eq(Object val) throws LeekRunException {
+		Number ret = mUAI.ushr(mValue, val);
+		return (Number) apply_eq(ret);
 	}
 
-	public double div_eq(Object val) throws LeekRunException {
-		return (double) (mValue = mUAI.div(mValue, val));
+	public Number div_eq(Object val) throws LeekRunException {
+		Number ret = mUAI.div(mValue, val);
+		return (Number) apply_eq(ret);
 	}
 
-	public Object div_eq_v1(Object val) throws LeekRunException {
+	public Object div_v1_eq(Object val) throws LeekRunException {
 		return mValue = mUAI.div_v1(mValue, val);
 	}
 
-	public long intdiv_eq(Object val) throws LeekRunException {
-		return (long) (mValue = mUAI.intdiv(mValue, val));
+	public Number intdiv_eq(Object val) throws LeekRunException {
+		Number ret = mUAI.intdiv(mValue, val);
+		return (Number) apply_eq(ret);
 	}
 
 	public Object mod_eq(Object val) throws LeekRunException {
-		return mValue = mUAI.mod(mValue, val);
+		Object ret = mUAI.mod(mValue, val);
+		return apply_eq(ret);
+	}
+	
+	private Object apply_eq(Object ret) {
+		if (mUAI.getVersion() >= 4 && mValue != null && mValue.getClass() != ret.getClass() && ret instanceof BigIntegerValue) {
+			if (mValue instanceof Long) {
+				return mValue = ((BigIntegerValue) ret).longValue();
+			} else if (mValue instanceof Double) {
+				return mValue = ((BigIntegerValue) ret).doubleValue();
+			}
+		}
+		return mValue = ret;
 	}
 
 	public Object get(Object index, ClassLeekValue fromClass) throws LeekRunException {

--- a/src/main/java/leekscript/runner/values/ClassLeekValue.java
+++ b/src/main/java/leekscript/runner/values/ClassLeekValue.java
@@ -2,6 +2,9 @@ package leekscript.runner.values;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigInteger;
+
+import leekscript.runner.values.BigIntegerValue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -323,7 +326,7 @@ public class ClassLeekValue extends FunctionLeekValue<Object> {
 		return result.div_eq(value);
 	}
 
-	public long field_intdiv_eq(String field, Object value) throws LeekRunException {
+	public Number field_intdiv_eq(String field, Object value) throws LeekRunException {
 		var result = getFieldL(field);
 		return result.intdiv_eq(value);
 	}
@@ -333,32 +336,32 @@ public class ClassLeekValue extends FunctionLeekValue<Object> {
 		return result.mod_eq(value);
 	}
 
-	public long field_bor_eq(String field, Object value) throws LeekRunException {
+	public Number field_bor_eq(String field, Object value) throws LeekRunException {
 		var result = getFieldL(field);
 		return result.bor_eq(value);
 	}
 
-	public long field_bxor_eq(String field, Object value) throws LeekRunException {
+	public Number field_bxor_eq(String field, Object value) throws LeekRunException {
 		var result = getFieldL(field);
 		return result.bxor_eq(value);
 	}
 
-	public long field_band_eq(String field, Object value) throws LeekRunException {
+	public Number field_band_eq(String field, Object value) throws LeekRunException {
 		var result = getFieldL(field);
 		return result.band_eq(value);
 	}
 
-	public long field_shl_eq(String field, Object value) throws LeekRunException {
+	public Number field_shl_eq(String field, Object value) throws LeekRunException {
 		var result = getFieldL(field);
 		return result.shl_eq(value);
 	}
 
-	public long field_shr_eq(String field, Object value) throws LeekRunException {
+	public Number field_shr_eq(String field, Object value) throws LeekRunException {
 		var result = getFieldL(field);
 		return result.shr_eq(value);
 	}
 
-	public long field_ushr_eq(String field, Object value) throws LeekRunException {
+	public Number field_ushr_eq(String field, Object value) throws LeekRunException {
 		var result = getFieldL(field);
 		return result.ushr_eq(value);
 	}
@@ -417,6 +420,7 @@ public class ClassLeekValue extends FunctionLeekValue<Object> {
 		if (this == ai.nullClass) return null;
 		if (this == ai.booleanClass) return false;
 		if (this == ai.integerClass) return 0l;
+		if (this == ai.bigIntegerClass) return new BigIntegerValue(ai, BigInteger.ZERO);
 		if (this == ai.realClass || this == ai.numberClass) return 0.0;
 		if (this == ai.stringClass) return "";
 		if (this == ai.legacyArrayClass) {

--- a/src/main/java/leekscript/runner/values/IntegerIntervalLeekValue.java
+++ b/src/main/java/leekscript/runner/values/IntegerIntervalLeekValue.java
@@ -9,6 +9,7 @@ import leekscript.AILog;
 import leekscript.common.Error;
 import leekscript.runner.AI;
 import leekscript.runner.LeekRunException;
+import leekscript.runner.RamUsage;
 
 public class IntegerIntervalLeekValue extends IntervalLeekValue {
 
@@ -376,15 +377,13 @@ public class IntegerIntervalLeekValue extends IntervalLeekValue {
 			var start = minClosed ? from : from + 1;
 			var end = maxClosed ? to : to - 1;
 			for (var i = start; i <= end; i += step) {
-				set.add(i);
-				ai.increaseRAM(1);
+				set.setPut(ai, i);
 			}
 		} else {
 			var start = maxClosed ? to : to - 1;
 			var end = minClosed ? from : from + 1;
 			for (var i = start; i >= end; i += step) {
-				set.add(i);
-				ai.increaseRAM(1);
+				set.setPut(ai, i);
 			}
 		}
 
@@ -405,15 +404,13 @@ public class IntegerIntervalLeekValue extends IntervalLeekValue {
 			var start = minClosed ? from : from + 1;
 			var end = maxClosed ? to : to - 1;
 			for (double i = start; i <= end; i += step) {
-				set.add(i);
-				ai.increaseRAM(1);
+				set.setPut(ai, i);
 			}
 		} else {
 			var start = maxClosed ? to : to - 1;
 			var end = minClosed ? from : from + 1;
 			for (double i = start; i >= end; i += step) {
-				set.add(i);
-				ai.increaseRAM(1);
+				set.setPut(ai, i);
 			}
 		}
 

--- a/src/main/java/leekscript/runner/values/LegacyArrayLeekValue.java
+++ b/src/main/java/leekscript/runner/values/LegacyArrayLeekValue.java
@@ -417,7 +417,7 @@ public class LegacyArrayLeekValue implements Iterable<Entry<Object, Object>>, Ge
 		return getOrCreate(ai, key).div_eq(value);
 	}
 
-	public long put_intdiv_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_intdiv_eq(AI ai, Object key, Object value) throws LeekRunException {
 		return getOrCreate(ai, key).intdiv_eq(value);
 	}
 
@@ -425,27 +425,27 @@ public class LegacyArrayLeekValue implements Iterable<Entry<Object, Object>>, Ge
 		return getOrCreate(ai, key).mod_eq(value);
 	}
 
-	public long put_bor_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_bor_eq(AI ai, Object key, Object value) throws LeekRunException {
 		return getOrCreate(ai, key).bor_eq(value);
 	}
 
-	public long put_band_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_band_eq(AI ai, Object key, Object value) throws LeekRunException {
 		return getOrCreate(ai, key).band_eq(value);
 	}
 
-	public long put_bxor_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_bxor_eq(AI ai, Object key, Object value) throws LeekRunException {
 		return getOrCreate(ai, key).bxor_eq(value);
 	}
 
-	public long put_shl_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_shl_eq(AI ai, Object key, Object value) throws LeekRunException {
 		return getOrCreate(ai, key).shl_eq(value);
 	}
 
-	public long put_shr_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_shr_eq(AI ai, Object key, Object value) throws LeekRunException {
 		return getOrCreate(ai, key).shr_eq(value);
 	}
 
-	public long put_ushr_eq(AI ai, Object key, Object value) throws LeekRunException {
+	public Number put_ushr_eq(AI ai, Object key, Object value) throws LeekRunException {
 		return getOrCreate(ai, key).ushr_eq(value);
 	}
 

--- a/src/main/java/leekscript/runner/values/ObjectLeekValue.java
+++ b/src/main/java/leekscript/runner/values/ObjectLeekValue.java
@@ -11,6 +11,7 @@ import leekscript.AILog;
 import leekscript.runner.AI;
 import leekscript.runner.LeekOperations;
 import leekscript.runner.LeekRunException;
+import leekscript.runner.RamUsage;
 import leekscript.common.AccessLevel;
 import leekscript.common.Error;
 
@@ -19,10 +20,12 @@ public class ObjectLeekValue implements LeekValue {
 	public final ClassLeekValue clazz;
 	public final int id;
 	public final LinkedHashMap<String, ObjectVariableValue> fields = new LinkedHashMap<>();
+	private final RamUsage ram;
 
-	public ObjectLeekValue(AI ai, ClassLeekValue clazz) {
+	public ObjectLeekValue(AI ai, ClassLeekValue clazz) throws LeekRunException {
 		this.clazz = clazz;
 		this.id = ai.getNextObjectID();
+		this.ram = ai.allocateRAM(this, 0, false);
 	}
 
 	public ObjectLeekValue(AI ai, String[] keys, Object[] values) throws LeekRunException {
@@ -42,12 +45,12 @@ public class ObjectLeekValue implements LeekValue {
 				fields.put(field.getKey(), new ObjectVariableValue(ai, LeekOperations.clone(ai, field.getValue().get(), level - 1), field.getValue().level, field.getValue().isFinal));
 			}
 		}
-		ai.increaseRAM(2 * value.fields.size());
+		ai.increaseRAM(ram, 2 * value.fields.size());
 	}
 
 	public void addField(AI ai, String field, Object value, AccessLevel level, boolean isFinal) throws LeekRunException {
 		fields.put(field, new ObjectVariableValue(ai, value, level, isFinal));
-		ai.increaseRAM(2);
+		ai.increaseRAM(ram, 2);
 	}
 
 	public Object getField(String field) throws LeekRunException {
@@ -242,7 +245,7 @@ public class ObjectLeekValue implements LeekValue {
 		throw new LeekRunException(Error.UNKNOWN_FIELD);
 	}
 
-	public long field_intdiv_eq(String field, Object value) throws LeekRunException {
+	public Number field_intdiv_eq(String field, Object value) throws LeekRunException {
 		var result = fields.get(field);
 		if (result != null) {
 			if (result.isFinal) {
@@ -266,7 +269,7 @@ public class ObjectLeekValue implements LeekValue {
 		throw new LeekRunException(Error.UNKNOWN_FIELD);
 	}
 
-	public long field_bor_eq(String field, Object value) throws LeekRunException {
+	public Number field_bor_eq(String field, Object value) throws LeekRunException {
 		var result = fields.get(field);
 		if (result != null) {
 			if (result.isFinal) {
@@ -278,7 +281,7 @@ public class ObjectLeekValue implements LeekValue {
 		throw new LeekRunException(Error.UNKNOWN_FIELD);
 	}
 
-	public long field_bxor_eq(String field, Object value) throws LeekRunException {
+	public Number field_bxor_eq(String field, Object value) throws LeekRunException {
 		var result = fields.get(field);
 		if (result != null) {
 			if (result.isFinal) {
@@ -290,7 +293,7 @@ public class ObjectLeekValue implements LeekValue {
 		throw new LeekRunException(Error.UNKNOWN_FIELD);
 	}
 
-	public long field_band_eq(String field, Object value) throws LeekRunException {
+	public Number field_band_eq(String field, Object value) throws LeekRunException {
 		var result = fields.get(field);
 		if (result != null) {
 			if (result.isFinal) {
@@ -302,7 +305,7 @@ public class ObjectLeekValue implements LeekValue {
 		throw new LeekRunException(Error.UNKNOWN_FIELD);
 	}
 
-	public long field_shl_eq(String field, Object value) throws LeekRunException {
+	public Number field_shl_eq(String field, Object value) throws LeekRunException {
 		var result = fields.get(field);
 		if (result != null) {
 			if (result.isFinal) {
@@ -314,7 +317,7 @@ public class ObjectLeekValue implements LeekValue {
 		throw new LeekRunException(Error.UNKNOWN_FIELD);
 	}
 
-	public long field_shr_eq(String field, Object value) throws LeekRunException {
+	public Number field_shr_eq(String field, Object value) throws LeekRunException {
 		var result = fields.get(field);
 		if (result != null) {
 			if (result.isFinal) {
@@ -326,7 +329,7 @@ public class ObjectLeekValue implements LeekValue {
 		throw new LeekRunException(Error.UNKNOWN_FIELD);
 	}
 
-	public long field_ushr_eq(String field, Object value) throws LeekRunException {
+	public Number field_ushr_eq(String field, Object value) throws LeekRunException {
 		var result = fields.get(field);
 		if (result != null) {
 			if (result.isFinal) {
@@ -567,13 +570,6 @@ public class ObjectLeekValue implements LeekValue {
 		}
 		sb.append("}");
 		return sb.toString();
-	}
-
-	@Override
-	@SuppressWarnings("deprecated")
-	protected void finalize() throws Throwable {
-		super.finalize();
-		clazz.ai.decreaseRAM(2 * size());
 	}
 
 	@Override

--- a/src/main/java/leekscript/runner/values/RealIntervalLeekValue.java
+++ b/src/main/java/leekscript/runner/values/RealIntervalLeekValue.java
@@ -284,13 +284,11 @@ public class RealIntervalLeekValue extends IntervalLeekValue {
 
 		if (step >= 0.0) {
 			for (var i = from; i <= to; i += step) {
-				set.add(i);
-				ai.increaseRAM(1);
+				set.setPut(ai, i);
 			}
 		} else {
 			for (var i = to; i >= from; i += step) {
-				set.add(i);
-				ai.increaseRAM(1);
+				set.setPut(ai, i);
 			}
 		}
 

--- a/src/main/java/leekscript/runner/values/SetLeekValue.java
+++ b/src/main/java/leekscript/runner/values/SetLeekValue.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import leekscript.runner.AI;
 import leekscript.runner.LeekOperations;
 import leekscript.runner.LeekRunException;
+import leekscript.runner.RamUsage;
 
 public class SetLeekValue extends HashSet<Object> implements LeekValue {
 
@@ -36,7 +37,7 @@ public class SetLeekValue extends HashSet<Object> implements LeekValue {
 
 	private final AI ai;
 	public final int id;
-
+	private RamUsage ram;
 
 	public SetLeekValue(AI ai) throws LeekRunException {
 		this(ai, new Object[0]);
@@ -48,13 +49,13 @@ public class SetLeekValue extends HashSet<Object> implements LeekValue {
 		for (Object value : values) {
 			this.add(value);
 		}
-		ai.increaseRAM(values.length);
+		this.ram = ai.allocateRAM(this, values.length);
 	}
 
 	public SetLeekValue(AI ai, SetLeekValue set, int level) throws LeekRunException {
 		this.ai = ai;
 		this.id = ai.getNextObjectID();
-		ai.increaseRAM(set.size());
+		this.ram = ai.allocateRAM(this, set.size());
 		for (var value : set) {
 			if (level == 1) {
 				this.add(value);
@@ -81,13 +82,6 @@ public class SetLeekValue extends HashSet<Object> implements LeekValue {
 			if (!set.contains(value)) return false;
 		}
 		return true;
-	}
-
-	@Override
-	@SuppressWarnings("deprecated")
-	protected void finalize() throws Throwable {
-		super.finalize();
-		ai.decreaseRAM(size());
 	}
 
 	@Override
@@ -134,18 +128,18 @@ public class SetLeekValue extends HashSet<Object> implements LeekValue {
 
 	public boolean setPut(AI ai, Object value) throws LeekRunException {
 		boolean added = add(value);
-		if (added) ai.increaseRAM(1);
+		if (added) ai.increaseRAM(ram, 1);
 		return added;
 	}
 
 	public boolean setRemove(AI ai, Object value) throws LeekRunException {
 		boolean removed = remove(value);
-		if (removed) ai.decreaseRAM(1);
+		if (removed) ai.decreaseRAM(ram, 1);
 		return removed;
 	}
 
 	public SetLeekValue setClear(AI ai) throws LeekRunException {
-		ai.decreaseRAM(size());
+		ai.decreaseRAM(ram, size());
 		clear();
 		return this;
 	}
@@ -180,7 +174,7 @@ public class SetLeekValue extends HashSet<Object> implements LeekValue {
 		var r = new SetLeekValue(ai);
 		r.addAll(this);
 		r.addAll(set);
-		ai.increaseRAM(r.size());
+		ai.increaseRAM(ram, r.size());
 		return r;
 	}
 
@@ -189,7 +183,7 @@ public class SetLeekValue extends HashSet<Object> implements LeekValue {
 		var r = new SetLeekValue(ai);
 		r.addAll(this);
 		r.retainAll(set);
-		ai.increaseRAM(r.size());
+		ai.increaseRAM(ram, r.size());
 		return r;
 	}
 
@@ -198,7 +192,7 @@ public class SetLeekValue extends HashSet<Object> implements LeekValue {
 		var r = new SetLeekValue(ai);
 		r.addAll(this);
 		r.removeAll(set);
-		ai.increaseRAM(r.size());
+		ai.increaseRAM(ram, r.size());
 		return r;
 	}
 
@@ -211,7 +205,7 @@ public class SetLeekValue extends HashSet<Object> implements LeekValue {
 		for (var e : set) {
 			if (!this.contains(e)) r.add(e);
 		}
-		ai.increaseRAM(r.size());
+		ai.increaseRAM(ram, r.size());
 		return r;
 	}
 

--- a/src/test/java/test/TestArrayStress.java
+++ b/src/test/java/test/TestArrayStress.java
@@ -7,7 +7,7 @@ public class TestArrayStress extends TestCommon {
 	public void run() throws Exception {
 
 		long fight_max_ops = 14l * 64l * 20000000l;
-		System.out.println("Fight max ops = " + fight_max_ops);
+//		System.out.println("Fight max ops = " + fight_max_ops);
 
 		/**
 		 * Stress test

--- a/src/test/java/test/TestBigInt.java
+++ b/src/test/java/test/TestBigInt.java
@@ -1,0 +1,1455 @@
+package test;
+
+import leekscript.common.Error;
+import leekscript.runner.LeekConstants;
+
+public class TestBigInt extends TestCommon {
+
+	public void run() throws Exception {
+
+		header("Big Integers");
+
+//		section("Performance");
+//		
+//		code_v4_("big_integer a = 1; for (var k in [0..100000]) {a = a << 1;}; return 0;").equals("0"); // warmup
+//		
+//		code_v4_("for (var k in [0..100000]) {var a = 5;}; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000]) {var a = 5L;}; return 0;").equals("0"); // x4-5 slower
+//		
+//		code_v4_("var a = 1; for (var k in [0..100000]) {a = a << 1;}; return 0;").equals("0");
+//		code_v4_("big_integer a = 1; for (var k in [0..100000]) {a = a << 1;}; return 0;").equals("0");
+//		code_v4_("big_integer a = 1; for (var k in [0..100000]) {a = a << 1;}; return 0;").equals("0");
+//		code_v4_("big_integer a = (1L << 1000) + 1; for (var k in [0..100000]) {a = a << 1;}; return 0;").equals("0");
+//		
+//		// test binString
+//		code_v4_("var a = 1, b = 1; for (var k in [0..100000])a = binString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1; for (var k in [0..100000]) a = binString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 156; for (var k in [0..1000]) a = binString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 312; for (var k in [0..1000]) a = binString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 625; for (var k in [0..1000]) a = binString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 1250; for (var k in [0..1000]) a = binString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 2500; for (var k in [0..1000]) a = binString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 5000; for (var k in [0..1000]) a = binString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 10000; for (var k in [0..1000]) a = binString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000; for (var k in [0..1000]) a = binString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 40000; for (var k in [0..1000]) a = binString(b); return 0;").equals("0");
+//
+//		// test hexString
+//		code_v4_("var a = 1, b = 1; for (var k in [0..100000])a = hexString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1; for (var k in [0..100000]) a = hexString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 156; for (var k in [0..1000]) a = hexString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 312; for (var k in [0..1000]) a = hexString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 625; for (var k in [0..1000]) a = hexString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 1250; for (var k in [0..1000]) a = hexString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 2500; for (var k in [0..1000]) a = hexString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 5000; for (var k in [0..1000]) a = hexString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 10000; for (var k in [0..1000]) a = hexString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000; for (var k in [0..1000]) a = hexString(b); return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 40000; for (var k in [0..1000]) a = hexString(b); return 0;").equals("0");
+//		
+//		// test string
+//		code_v4_("integer x = 999; for (var k in [0..10000]) var a = string(x); return 0").equals("0");
+//		code_v4_("big_integer x = 999; for (var k in [0..10000]) var a = string(x); return 0").equals("0");
+//		code_v4_("big_integer x = (12345678912L * (10L**20)) + 12345678987654321; for (var k in [0..10000]) var a = string(x); return 0").equals("0");
+//		code_v4_("big_integer x = (12345678912L * (10L**100)) + 12345678987654321; for (var k in [0..10000]) var a = string(x); return 0").equals("0");
+//		code_v4_("big_integer x = (12345678912L * (10L**1000)) + 12345678987654321; for (var k in [0..10000]) var a = string(x); return 0").equals("0");
+//		
+//		// test <<
+//		code_v4_("for (var k in [0..100000])var a = 1 << 1; return 0;").equals("0"); // ref
+//		code_v4_("big_integer a = 0;for (var k in [0..100000])a = 1L << 1; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 78; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 156; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 312; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 625; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 1250; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 2500; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 5000; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 10000; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 20000; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 40000; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 80000; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 160000; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 320000; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 640000; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 1280000; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 2560000; return 0;").equals("0");
+//		code_v4_("for (var k in [0..100000])big_integer a = 1L << 5120000; return 0;").equals("0");
+//	
+//		// test &
+//		code_v4_("var a = 1, b = 1; for (var k in [0..100000])a = a & b; return 0;").equals("0"); // ref
+//		code_v4_("big_integer a = 1, b = 1; for (var k in [0..100000]) a = a & b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 156; for (var k in [0..100000]) a = a & b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 312; for (var k in [0..100000]) a = a & b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 625; for (var k in [0..100000]) a = a & b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 1250; for (var k in [0..100000]) a = a & b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 2500; for (var k in [0..100000]) a = a & b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 5000; for (var k in [0..100000]) a = a & b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 10000; for (var k in [0..100000]) a = a & b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000; for (var k in [0..100000]) a = a & b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 40000; for (var k in [0..100000]) a = a & b; return 0;").equals("0");
+//		
+//		// test |
+//		code_v4_("var a = 1, b = 1; for (var k in [0..100000])a = a | b; return 0;").equals("0"); // ref
+//		code_v4_("big_integer a = 1, b = 1; for (var k in [0..100000]) a = a | b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 156; for (var k in [0..100000]) a = a | b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 312; for (var k in [0..100000]) a = a | b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 625; for (var k in [0..100000]) a = a | b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 1250; for (var k in [0..100000]) a = a | b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 2500; for (var k in [0..100000]) a = a | b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 5000; for (var k in [0..100000]) a = a | b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 10000; for (var k in [0..100000]) a = a | b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000; for (var k in [0..100000]) a = a | b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 40000; for (var k in [0..100000]) a = a | b; return 0;").equals("0");
+//		
+//		// test ^
+//		code_v4_("var a = 1, b = 1; for (var k in [0..100000])a = a ^ b; return 0;").equals("0"); // ref
+//		code_v4_("big_integer a = 1, b = 1; for (var k in [0..100000]) a = a ^ b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 156; for (var k in [0..100000]) a = a ^ b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 312; for (var k in [0..100000]) a = a ^ b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 625; for (var k in [0..100000]) a = a ^ b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 1250; for (var k in [0..100000]) a = a ^ b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 2500; for (var k in [0..100000]) a = a ^ b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 5000; for (var k in [0..100000]) a = a ^ b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 10000; for (var k in [0..100000]) a = a ^ b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000; for (var k in [0..100000]) a = a ^ b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 40000; for (var k in [0..100000]) a = a ^ b; return 0;").equals("0");
+//		
+//		// test ~
+//		code_v4_("var b = 1; for (var k in [0..100000])b = ~b; return 0;").equals("0"); // ref
+//		code_v4_("big_integer b = 1; for (var k in [0..100000]) b = ~b; return 0;").equals("0");
+//		code_v4_("big_integer b = 1L << 156; for (var k in [0..100000]) b = ~b; return 0;").equals("0");
+//		code_v4_("big_integer b = 1L << 312; for (var k in [0..100000]) b = ~b; return 0;").equals("0");
+//		code_v4_("big_integer b = 1L << 625; for (var k in [0..100000]) b = ~b; return 0;").equals("0");
+//		code_v4_("big_integer b = 1L << 1250; for (var k in [0..100000]) b = ~b; return 0;").equals("0");
+//		code_v4_("big_integer b = 1L << 2500; for (var k in [0..100000]) b = ~b; return 0;").equals("0");
+//		code_v4_("big_integer b = 1L << 5000; for (var k in [0..100000]) b = ~b; return 0;").equals("0");
+//		code_v4_("big_integer b = 1L << 10000; for (var k in [0..100000]) b = ~b; return 0;").equals("0");
+//		code_v4_("big_integer b = 1L << 20000; for (var k in [0..100000]) b = ~b; return 0;").equals("0");
+//		code_v4_("big_integer b = 1L << 40000; for (var k in [0..100000]) b = ~b; return 0;").equals("0");
+//		
+//		// test +
+//		code_v4_("integer a = 1, b = 1; for (var k in [0..100000]) a = b + b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 156; for (var k in [0..100000]) a = b + b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 312; for (var k in [0..100000]) a = b + b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 625; for (var k in [0..100000]) a = b + b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 1250; for (var k in [0..100000]) a = b + b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 2500; for (var k in [0..100000]) a = b + b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 5000; for (var k in [0..100000]) a = b + b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 10000; for (var k in [0..100000]) a = b + b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000; for (var k in [0..100000]) a = b + b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 40000; for (var k in [0..100000]) a = b + b; return 0;").equals("0");
+//		
+//		// test *
+//		code_v4_("var a = 1, b = 1; for (var k in [0..100000]) a = b * b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 156; for (var k in [0..100000]) a = b * b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 312; for (var k in [0..100000]) a = b * b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 625; for (var k in [0..100000]) a = b * b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 1250; for (var k in [0..100000]) a = b * b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 2500; for (var k in [0..100000]) a = b * b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 5000; for (var k in [0..100000]) a = b * b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 10000; for (var k in [0..100000]) a = b * b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000; for (var k in [0..100000]) a = b * b; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 40000; for (var k in [0..100000]) a = b * b; return 0;").equals("0");
+//		
+//		
+//		// test /
+//		code_v4_("var a = 1, b = 10, c = b / 2; for (var k in [0..100000]) a = b / c; return a;").equals("2.0");
+//		code_v4_("big_integer a = 1, b = 1L << 156, c = b / 2; for (var k in [0..100000]) a = b / c; return a;").equals("2");
+//		code_v4_("big_integer a = 1, b = 1L << 312, c = b / 2; for (var k in [0..100000]) a = b / c; return a;").equals("2");
+//		code_v4_("big_integer a = 1, b = 1L << 625, c = b / 2; for (var k in [0..100000]) a = b / c; return a;").equals("2");
+//		code_v4_("big_integer a = 1, b = 1L << 1250, c = b / 2; for (var k in [0..100000]) a = b / c; return a;").equals("2");
+//		code_v4_("big_integer a = 1, b = 1L << 2500, c = b / 2; for (var k in [0..100000]) a = b / c; return a;").equals("2");
+//		code_v4_("big_integer a = 1, b = 1L << 5000, c = b / 2; for (var k in [0..100000]) a = b / c; return a;").equals("2");
+//		code_v4_("big_integer a = 1, b = 1L << 10000, c = b / 2; for (var k in [0..100000]) a = b / c; return a;").equals("2");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = b / 2; for (var k in [0..100000]) a = b / c; return a;").equals("2");
+//		code_v4_("big_integer a = 1, b = 1L << 40000, c = b / 2; for (var k in [0..100000]) a = b / c; return a;").equals("2");
+//		
+//		
+//		// test **
+//		code_v4_("var a = 1, b = 10, c = 30; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 156, c = 30; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 312, c = 30; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 625, c = 30; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 1250, c = 30; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 2500, c = 30; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 5000, c = 30; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 10000, c = 30; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 30; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 40000, c = 30; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 3; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 6; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 12; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 24; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 48; for (var k in [0..100000]) a = b ** c; return 0;").equals("0");
+//		
+//		// test %
+//		code_v4_("var a = 1, b = 10, c = 3; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 156, c = 3; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 312, c = 3; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 625, c = 3; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 1250, c = 3; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 2500, c = 3; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 5000, c = 3; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 10000, c = 3; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 3; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 40000, c = 3; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 3; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 6; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 12; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 24; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 48; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 480; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 4800; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = 48000; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		code_v4_("big_integer a = 1, b = 1L << 20000, c = b/2; for (var k in [0..100000]) a = b % c; return 0;").equals("0");
+//		
+//		section("Limits");
+//		code_v4_("var a = 2L ** 200_000_000; a -= 1; return 0").equals("0");
+//		code_v4_("var a = 2L ** 700_000_000; return 0").equals("0");
+//		code_v4_("var a = 2L ** 214748364; return 0").equals("0");
+//		code_v4_("2L ** 2147483646;").error(Error.OUT_OF_MEMORY);
+//		code_v4_("2L ** 2147483647;").any_error();
+
+		section("Basic numbers");
+		code_v4_("return 0L").equals("0");
+		code_v4_("return -1L").equals("-1");
+		code_v4_("return -(-1L)").equals("1");
+
+		// does not work (BigInteger does not parse this notation)
+		//code_v4_("return -1e100L").equals("-10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+		// need to use long to go from double to BigInteger, so we lose information
+		// code_v4_("return -1e100 as BigInteger").equals("-10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+		// code_v4_("return 1e100 as big_integer").equals("10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+
+		code_v4_("return 1e+3 as big_integer").equals("1000");
+		code_v4_("return 1e+3+2 as BigInteger").equals("1002");
+		code_v4_("return 1e+3-2 as BigInteger").equals("998");
+		code_v4_("return 1.5e-3 as big_integer").equals("0");
+		code_v4_("return 1.99 as big_integer").equals("1");
+		code_v4_("return 1L as big_integer").equals("1");
+		code_v4_("return 1L as real").equals("1.0");
+		code_v4_("return 1L as integer").equals("1");
+		code_v4_("big_integer x = 1L; return x as integer").equals("1");
+		code_v4_("var x = 1L; return x as integer").equals("1");
+		code_v4_("BigInteger x = 1L; return x as integer").equals("1");
+
+		section("Class");
+		code_v4_("return BigInteger();").equals("0");
+		code_v4_("return new BigInteger();").equals("0");
+		code_v4_("return BigInteger() + 1;").equals("1");
+		code_v4_("return BigInteger() - 1;").equals("-1");
+		code_v4_("return (BigInteger() + 1) << 100;").equals("1267650600...6703205376");
+
+		section("Lexical errors");
+		code_v4_("123451234548975415644561534894564896785416r").error(Error.INVALID_NUMBER);
+		code_v4_("0b011001711111111111111111111111111111111111111111111111111111111111111111111111111111111111L").error(Error.INVALID_NUMBER);
+		code_v4_("0x+123451234548975415644561534894564896785416").error(Error.INVALID_NUMBER);
+		code_v4_("0b#123451234548975415644561534894564896785416").error(Error.INVALID_CHAR);
+		code_v4_("0b'123451234548975415644561534894564896785416").error(Error.STRING_NOT_CLOSED);
+		code_v4_("0b\"123451234548975415644561534894564896785416").error(Error.STRING_NOT_CLOSED);
+		code_v4_("0xeazblqzd123451234548975415644561534894564896785416").error(Error.INVALID_NUMBER);
+		code_v4_("0xffxff123451234548975415644561534894564896785416").error(Error.INVALID_NUMBER);
+		code_v4_("0b101b01011111111111111111111111111111111111111111111111111111111111111111111111111111111111").error(Error.INVALID_NUMBER);
+		code_v4_("0b101x01011111111111111111111111111111111111111111111111111111111111111111111111111111111111").error(Error.INVALID_NUMBER);
+		code_v4_("0b101.01011111111111111111111111111111111111111111111111111111111111111111111111111111111111").error(Error.INVALID_NUMBER);
+		code_v4_("0.1L").error(Error.INVALID_NUMBER);
+
+		section("Basic operations");
+		code_v4_("return 2L + 5;").equals("7");
+		code_v4_("return 2 + 1267650600228229401496703205376L;").equals("1267650600...6703205378");
+		code_v4_("return 1267650600228229401496703205376L;").equals("1267650600...6703205376");
+		code_v4_("return 1L << 100;").equals("1267650600...6703205376");
+		code_v4_("big_integer x = 12; return x;").equals("12");
+		code_v4_("big_integer x = 1; return x << 150 == 1427247692705959881058285969449495136382746624L;").equals("true");
+		code_v4_("big_integer x = 1427247692705959881058285969449495136382746624; return x + 1;").equals("1427247692...6382746625");
+		code_v4_("return BigInteger();").equals("0");
+		code_v4_("return new BigInteger();").equals("0");
+		code_v4_("return (BigInteger() + 1) << 100;").equals("1267650600...6703205376");
+		code_v4_("return 5L == 5;").equals("true");
+		code_v4_("return 5L == 5.0;").equals("true");
+		code_v4_("return 5L == 5L;").equals("true");
+
+		code_v4_("return 1267650600228229401496703205376L == 1267650600228229401496703205376;").equals("true");
+		code_v4_("return 1267650600228229401496703205376L == 1267650600228229401496703205377;").equals("false");
+		code_v4_("return 1267650600228229401496703205376L == (BigInteger() + 1) << 104 >>> 2 >> 2;").equals("true");
+		
+		code_v4_("return 0x8fa6cd83e41a6f4ecL").equals("1656189881...8544180460");
+		code_v4_("-0xa71ed8fa6cd83e41a6f4eaf4ed9dff8cc3ab1e9a4ec6baf1ea77db4fa1c").equals("-7208895554...8059287068");
+		code_v4_("0xfe54c4ceabf93c4eaeafcde94eba4c79741a7cc8ef43daec6a71ed8fa6cd8b3e41a6f4ea7f4ed9dff8cc3ab61e9a4ec6baf1ea77deb4fa1c").equals("7221004400...1654073884");
+		code_v4_("return 0b010101010101110101010101011111111110111110111110000000011101101010101001").equals("1574698668...1521295017");
+		code_v4_("return -0b101010101011101010101010111111111101111101111100000000111011010101010010011111100000011111111111110000").equals("-3381639641...3319995376");
+
+		code_v4_("return 5L + 5;").equals("10");
+		code_v4_("return 10 - 3L;").equals("7");
+		code_v4_("return -2L + 3;").equals("1");
+		code_v4_("return 5 * 5L;").equals("25");
+		code_v4_("return 15L / 3;").equals("5");
+		code_v4_("return 15L \\ 3;").equals("5");
+		code_v4_("return 15 / 3L;").equals("5");
+		code_v4_("return 15 \\ 3L;").equals("5");
+		code_v4_("return 15L / 2;").equals("7");
+		code_v4_("return 15 / 2L;").equals("7");
+		code_v4_("return 12L ** 2;").equals("144");
+		code_v4_("return 2 ** 5L;").equals("32");
+		code_v4_("return 2L < 5;").equals("true");
+		code_v4_("return 12 < 5L;").equals("false");
+		code_v4_("return 5L == 12;").equals("false");
+		code_v4_("return 12 == 12L;").equals("true");
+		code_v4_("return -12L * 2;").equals("-24");
+		code_v4_("return (-12) * 2L;").equals("-24");
+		code_v4_("return -12L ** 2;").equals("144");
+		code_v4_("return (-12) ** 2L;").equals("144");
+		code_v4_("return -12L + 2;").equals("-10");
+		code_v4_("var a = [2L, 'a'] return [-a[0], ~a[0]] == [-2, ~2];").equals("true");
+
+
+		code_v4_("var x = 5L + 5; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = 10 - 3L; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = -2L + 3; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = 5 * 5L; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = 15L / 3; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = 15L \\ 3; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = 15 / 3L; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = 15 \\ 3L; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = 15L / 2; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = 15 / 2L; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = 12L ** 2; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = 12L ** 2; return x instanceof Number").equals("true");
+		code_v4_("var x = 12L ** 2; return x instanceof Integer").equals("false");
+		code_v4_("var x = 2 ** 5L; return x instanceof Integer").equals("true");
+		code_v4_("var x = -12L * 2; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = (-12) * 2L; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = -12L ** 2; return x instanceof BigInteger").equals("true");
+		code_v4_("var x = (-12) ** 2L; return x instanceof Integer").equals("true");
+		code_v4_("var x = -12L + 2; return x instanceof BigInteger").equals("true");
+		code_v4_("var a = [2L, 'a'] return -a[0] instanceof BigInteger && ~a[0] instanceof BigInteger").equals("true");
+
+		section("Hexadecimal representation");
+		code_v4_("return 0x0L;").equals("0");
+		code_v4_("return 0x00000000L").equals("0");
+		code_v4_("return 0x1L").equals("1");
+		code_v4_("return 0x00000001L").equals("1");
+		code_v4_("return 0xfL").equals("15");
+		code_v4_("return 0x0000000fL").equals("15");
+		code_v4_("return -0xfL").equals("-15");
+		code_v4_("return 0xffL").equals("255");
+		code_v4_("return 0x10L").equals("16");
+		code_v4_("return -0xffffL").equals("-65535");
+		code_v4_("return 0xffffffffL").equals("4294967295");
+		code_v4_("return 0x7FFFFFFFFFFFFFFFL").equals("9223372036854775807");
+		
+		section("Binary representation");
+		code_v4_("return 0b0L").equals("0");
+		code_v4_("return 0b00001L").equals("1");
+		code_v4_("return 0b1001010110L").equals("598");
+		code_v4_("return -0b0101101001111L").equals("-2895");
+		code_v4_("return 0b0111111111111111111111111111111111111111111111111111111111111111L").equals("9223372036854775807");
+		
+		section("Underscore delimiters");
+		code_v4_("return 1_000_123L").equals("1000123");
+		code_v4_("return 1_000__123L").error(Error.MULTIPLE_NUMERIC_SEPARATORS);
+		code_v4_("return 0x_ffL").equals("255");
+		code_v4_("return 0xff_ff_ff_ffL").equals("4294967295");
+		code_v4_("return 0b1001_0101_10L").equals("598");
+		code_v4_("return 5.001_002_003L").error(Error.INVALID_NUMBER);
+		code_v4_("return 5.001_002_003L").error(Error.INVALID_NUMBER);
+		code_v4_("return _1_000_000L").error(Error.UNKNOWN_VARIABLE_OR_FUNCTION);
+
+		section("null handling");
+		code_v4_("return null == 0L;").equals("false");
+		code_v4_("return null < 0L;").equals("false");
+		code_v4_("null + 5L").equals("5");
+		code_v4_("5L + null").equals("5");
+		//code_v4_("5L / null").equals("∞"); // cast error
+		code_v4_("null / 12L").equals("0");
+		code_v4_("null * 5L").equals("0");
+		code_v4_("5L * null").equals("0");
+
+
+		section("Numbers with variables");
+		code_v4_("var a = 2L return a++;").equals("2");
+		code_v4_("var a = 2L; return ++a;").equals("3");
+		code_v4_("var a = 2L return a--;").equals("2");
+		code_v4_("var a = 2L; return --a;").equals("1");
+		code_v4_("var a = 2L return a += 5;").equals("7");
+		code_v4_("var a = 2 return a += 5L;").equals("7");
+		code_v4_("var a = 2L return a += 5L;").equals("7");
+		code_v4_("var a = 2L return a -= 5;").equals("-3");
+		code_v4_("var a = 2L return a *= 5;").equals("10");
+		code_v4_("var a = 100L return a /= 5;").equals("20");
+		code_v4_("var a = 100 return a /= 5L;").equals("20");
+		code_v4_("var a = 100L return a /= 5L;").equals("20");
+		code_v4_("var a = 56L return a %= 17;").equals("5");
+		code_v4_("var a = 56 return a %= 17L;").equals("5");
+		code_v4_("var a = 56L return a %= 17L;").equals("5");
+		code_v4_("var a = 15L return a **= 2;").equals("225");
+//		code_v4_("var a = 1L return a * 0.5;").equals("0.5"); // 0.5 converted to bigint
+//		code_v4_("var a = 1.5 return a * 2L;").equals("3");	  // 1.5 converted to bigint
+		code_v4_("var i = 1L return i = i + 2L;").equals("3");
+		code_v4_("var a = 10L; a += 10L - 2 * 3L; return a;").equals("14");
+
+		section("multiple operations");
+		code_v4_("return (33 - 2) / 2L;").equals("15");
+		code_v4_("return (32L - 2) / 2;").equals("15");
+		code_v4_("return 12 < (45L / 4);").equals("false");
+		code_v4_("return 12L == (24 / 2);").equals("true");
+		code_v4_("return (2.5 * 4.7) + 0L;").equals("11");
+		code_v4_("return (2.5 * 4.7) as BigInteger;").equals("11");
+		code_v4_("return 5L * 2L + 3L * 4;").equals("22");
+
+		section("Multiple precision numbers");
+		 code_v4_("123445321324234567895431235648945674894561564523489756489").equals("1234453213...3489756489");
+		 code_v4_("var a = 10L a").equals("10");
+		 code_v4_("0L").equals("0");
+		 code_v4_("0xf45eab5c9d13aab44376beff").equals("7562879065...1594128127");
+		 code_v4_("0xf45eab5c9d13aab44376beffL").equals("7562879065...1594128127");
+		 code_v4_("var a = 1209876543789765432456765432087654321 a").equals("1209876543...2087654321");
+		 code_v4_("var a = { id:1209876543789765432456765432087654321 } a.id").equals("1209876543...2087654321");
+		 code_v4_("var a = 5L a = 12L").equals("12");
+		 code_v4_("var a = 5L a = 12L a").equals("12");
+		 code_v4_("var f = -> 12L string(f())").equals("\"12\"");
+
+//		section("Integer division by zero");
+//		 code_v4_("1L \\ 0").exception(ls::vm::Exception::DIVISION_BY_ZERO);
+//		 code_v4_("1L % 0").exception(ls::vm::Exception::DIVISION_BY_ZERO);
+
+		section("Constructor");
+		code_v4_("return BigInteger").equals("<class BigInteger>");
+		code_v4_("BigInteger()").equals("0");
+
+		section("Constants");
+		code_v4_("return PI as big_integer").equals("3");
+		code_v4_("return 0L == NaN").equals("false");
+		code_v4_("return 0L == ∞").equals("false");
+		code_v4_("return 0L == -∞").equals("false");
+
+		/*
+		 * Operators
+		 */
+		section("Number.operator unary -");
+		code_v4_("var a = [12L, ''] var b = a[0]; return -b;").equals("-12");
+		code_v4_("return -(12L ** 2L);").equals("-144");
+
+		section("Number.operator unary !");
+		code_v4_("var a = [12L, ''] var b = a[0]; return !b;").equals("false");
+
+		section("Number.operator unary ~");
+		code_v4_("var a = [12L, ''] var b = a[0]; return ~b;").equals("-13");
+		code_v4_("var a = 12L return ['', ~a];").equals("[\"\", -13]");
+
+		section("Number.operator ++x");
+		code_v4_("var a = 20L; return ++a;").equals("21");
+		code_v4_("var a = 30L; ++a return a;").equals("31");
+		code_v4_("var a = 20L; var b = ++a return b;").equals("21");
+		code_v4_("var a = 20L; var b = ++a return b instanceof BigInteger;").equals("true");
+		code_v4_("var a = 5L return ['', ++a];").equals("[\"\", 6]");
+
+		section("Number.operator --x");
+		code_v4_("var a = 20L; return --a;").equals("19");
+		code_v4_("var a = 30L; --a return a;").equals("29");
+		code_v4_("var a = 5L return ['', --a];").equals("[\"\", 4]");
+
+		section("Number.operator x++");
+		code_v4_("var a = 20L; return a++;").equals("20");
+		code_v4_("var a = 20L; a++ return a;").equals("21");
+		code_v4_("var a = 20L; var b = a++ return b;").equals("20");
+
+		section("Number.operator x--");
+		code_v4_("var a = 20L; return a--;").equals("20");
+		code_v4_("var a = 20L; a-- return a;").equals("19");
+		code_v4_("var a = 20L; var b = a-- return b;").equals("20");
+
+		section("Number.operator =");
+		code_v4_("var a = 1L, b = 4L; a = b").equals("4");
+
+		section("Number.operator ==");
+		code_v4_("return 12L == 12;").equals("true");
+		code_v4_("return 12L == 12L;").equals("true");
+		code_v4_("return 12 == 12L;").equals("true");
+		code_v4_("return 13L == 12;").equals("false");
+		code_v4_("return 13L == 12L;").equals("false");
+		code_v4_("return 12L ** 5L == 12 ** 5;").equals("true");
+		code_v4_("return 12 ** 5L == (3L * 4) ** 5;").equals("true");
+		code_v4_("return 12L ** 5 == 248832;").equals("true");
+		code_v4_("return 248832 == 12L ** 5L;").equals("true");
+		code_v4_("12L ** 5L == (3L * 4L) ** 5L").equals("true");
+
+		section("Number.operator +");
+		code_v4_("return 1L + 2L;").equals("3");
+		code_v4_("return 1L + (2 + 3L);").equals("6");
+		code_v4_("return (1 + 2) + 3L;").equals("6");
+		code_v4_("return (1L + 2) + (3 + 4L);").equals("10");
+		code_v4_("(1L + 2L) + (3L + 4L)").equals("10");
+		code_v4_("return 15L + false;").equals("15");
+		code_v4_("return 15L + true;").equals("16");
+		code_v4_("var a = 15L return a + true;").equals("16");
+		code_v4_("var a = ['a', 12321111111111111111111111111111111321321321999999] a[1] + 123456789").equals("1232111111...1445456788");
+		code_v4_("return 10000L + (-15);").equals("9985");
+		code_v4_("return 10000L + (-15L);").equals("9985");
+		code_v4_("return null + 2L;").equals("2");
+		code_v4_("return 2L + null;").equals("2");
+
+		section("Number.operator +=");
+		code_v4_("var a = 15L a += true return a;").equals("16");
+		code_v4_("var a = 10L return a += 4;").equals("14");
+		code_v4_("var a = 10L a += 4 return a;").equals("14");
+		code_v4_("var a = 15L return ['', a += 7];").equals("[\"\", 22]");
+		code_v4_("var a = 10L a += 5 return a;").equals("15");
+		code_v4_("var a = 10L a += 78 return a;").equals("88");
+		code_v4_("var a = 10L a += (-6) return a;").equals("4");
+
+		section("Number.operator -");
+		code_v4_("return -12L").equals("-12");
+		code_v4_("return -0L").equals("0");
+		code_v4_("return 1L - 2;").equals("-1");
+		code_v4_("return 1L - (2 - 3);").equals("2");
+		code_v4_("return (1L - 2) - 3;").equals("-4");
+		code_v4_("return (1L - 2) - (3 - 4);").equals("0");
+		code_v4_("return (10L + 10) - 1;").equals("19");
+		code_v4_("return 15L - 3L;").equals("12");
+		code_v4_("return 15L - false;").equals("15");
+		code_v4_("return 15L - true;").equals("14");
+		code_v4_("return -1512352456458153156482648564615647864561465487456418784543875L - 1;").equals("-1512352456...8784543876");
+		code_v4_("var a = 15L return a - true;").equals("14");
+		code_v4_("var a = 100L return a - 20;").equals("80");
+		code_v4_("return 12L - null;").equals("12");
+		code_v4_("return null - 12L;").equals("-12");
+
+		section("Number.operator -=");
+		code_v4_("var a = 15L a -= true return a;").equals("14");
+		code_v4_("var a = 15L return ['', a -= 6];").equals("[\"\", 9]");
+
+		section("Number.operator *");
+		code_v4_("return 3L * 4;").equals("12");
+		code_v4_("return 10L + 3 * 4L;").equals("22");
+		code_v4_("return (5L + 2L) * (16L * 2L);").equals("224");
+		code_v4_("return 12L * false;").equals("0");
+		code_v4_("var a = 13L; return a * false;").equals("0");
+		code_v4_("return 13L * true;").equals("13");
+		code_v4_("return 7L * 2;").equals("14");
+		code_v4_("var a = 6L; return a * 3;").equals("18");
+		code_v4_("12344532132423123456789 * 9876578976134127895615248960").equals("1219217465...6037189440");
+		code_v4_("var a = ['a', 12321111111111111111111111111111111321321321999999] a[1] * 123456789").equals("1521124814...4934543211");
+		code_v4_("return null * 2L;").equals("0");
+		code_v4_("return 2L * null;").equals("0");
+
+		section("Number.operator *=");
+		code_v4_("var a = 15L a *= true return a;").equals("15");
+		code_v4_("var a = 15L a *= false return a;").equals("0");
+		code_v4_("var a = 15L a *= null return a;").equals("0");
+		code_v4_("var a = 15L; return ['', a *= 2];").equals("[\"\", 30]");
+		code_v4_("var a = 15L; return ['', a *= 2L];").equals("[\"\", 30]");
+		code_v4_("var a = 5 a *= 0L return a;").equals("0");
+		code_v4_("var a = 5L a *= 12 return a;").equals("60");
+		code_v4_("var a = 5L a *= 5L return a;").equals("25");
+		code_v4_("var a = null a *= 5L return a;").equals("0");
+		code_strict("var a = null a *= 5L return a;").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("any a = null a *= 5L return a;").equals("0");
+		code_v4_("var a = null a *= null return a;").equals("0");
+		code_strict("var a = null a *= null return a;").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("any a = null a *= null return a;").equals("0");
+		code_v4_("var a = null return a *= 5L").equals("0");
+		code_strict("var a = null return a *= 5L").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("any a = null return a *= 5L").equals("0");
+		code_v4_("var a = 91591785496891278315799124157189514175L a *= 157854689278315792457851475L a").equals("1445819284...9557158125");
+
+
+		section("Number.operator **");
+		code_v4_("return 14L ** 3;").equals("2744");
+		code_v4_("return 14L ** null;").equals("1");
+		code_v4_("return null ** 2L;").equals("0");
+		code_v4_("return 0L ** 0;").equals("1");
+		code_v4_("257L ** 20").equals("1580019571...5213952001");
+		code_v4_("2L ** 50").equals("1125899906842624");
+		code_v4_("(5L + 2L) ** (16L * 2L)").equals("1104427674...6305299201");
+		code_v4_("var s = 0L s = 5L ** 2 return s;").equals("25");
+
+		section("Number.operator **=");
+		code_v4_("var a = 5L; a **= 4 return a").equals("625");
+		code_v4_("var a = 5L; return a **= 4").equals("625");
+		code_v4_("var a = 5L; return a **= true").equals("5");
+		code_v4_("var a = null a **= 5L return a").equals("0");
+		//code_strict("var a = null a **= 5L return a").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		//code_strict("any a = null return a **= 5L").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+
+		section("Number.operator %");
+		code_v4_("return 721L % 57;").equals("37");
+		code_v4_("return false % 3L;").equals("0");
+		code_v4_("return true % 3L;").equals("1");
+		code_v4_("var a = 721L return a % 57L;").equals("37");
+		code_v4_("var a = null return a % 57L;").equals("0");
+		code_v4_("123456789123456789L % 234567L").equals("221463");
+		code_v4_("(12L ** 40L) % 234567L").equals("228798");
+		code_v4_("100000L % (12L ** 3L)").equals("1504");
+		code_v4_("(100000L * 10L) % (12L ** 3L)").equals("1216");
+
+		section("Number.operator %=");
+		code_v4_("var a = 721L return a %= 17;").equals("7");
+
+		section("Number.operator /");
+//		code_v4_("8L / 0").equals("null");	// cast error with division by 0
+//		code_v4_("8L / 0L").equals("∞");
+//		code_v4_("8L / null").equals("null");
+//		code_v4_("8L / null").equals("∞");
+		code_v4_("null / 5L").equals("0");
+		code_v4_("return 13L / true;").equals("13");
+		code_v4_("return 14L / 2;").equals("7");
+		code_v4_("var a = 18L; return a / 3;").equals("6");
+		code_v4_("var a = 18; return a / 3L;").equals("6");
+		code_v4_("var a = 17L, b = 5L return a / b;").equals("3");
+		code_v4_("var a = 17, b = 5L return a / b;").equals("3");
+
+		section("Number.operator /=");
+		code_v4_("var a = 12L a /= 3 return a;").equals("4");
+		code_v4_("var a = 12 a /= 3L return a;").equals("4");
+		code_strict("var a = 12L a /= 3 return a;").equals("4");
+		code_v4_("var a = 12L a /= true return a;").equals("12");
+		code_strict("var a = 12L a /= true return a;").equals("12");
+		code_v4_("var a = null a /= 5L return a;").equals("0");
+		code_v4_("var a = 15L; return ['', a /= 2];").equals("[\"\", 7]");
+		code_v4_("var a = 15; return ['', a /= 2L];").equals("[\"\", 7]");
+
+		section("Number.operator <");
+		code_v4_("return 5L < 2;").equals("false");
+		code_v4_("return 2 < 5L;").equals("true");
+		code_v4_("return 5.1 < 2L;").equals("false");
+		code_v4_("return 2L < 5.1;").equals("true");
+		code_v4_("3L < 4L").equals("true");
+		code_v4_("10L < (3L * 4L)").equals("true");
+		code_v4_("(5L + 5L) < (3L * 4L)").equals("true");
+		code_v4_("(5L + 5L) < 12L").equals("true");
+		code_v4_("3L < 4").equals("true");
+		code_v4_("return 3 < [];").equals("false");
+		code_v4_("return true < [];").equals("false");
+
+		section("Number.operator <=");
+		code_v4_("return 5L <= 2;").equals("false");
+		code_v4_("return 2 <= 5L;").equals("true");
+		code_v4_("return 5.1 <= 2L;").equals("false");
+		code_v4_("return 2L <= 5.1;").equals("true");
+		code_v4_("return 5.1 <= 5L;").equals("false");
+		code_v4_("return 5L <= 5.1;").equals("true");
+		code_v4_("3L <= 4L").equals("true");
+		code_v4_("10L <= (3L * 4L)").equals("true");
+		code_v4_("(5L + 5L) <= (3L * 4L)").equals("true");
+		code_v4_("(5L + 5L) <= 12L").equals("true");
+		code_v4_("3L <= 4").equals("true");
+		code_v4_("return 3 <= [];").equals("false");
+		code_v4_("return true <= [];").equals("false");
+
+		section("Number.operator >");
+		code_v4_("return 5L > 2;").equals("true");
+		code_v4_("return 2 > 5L;").equals("false");
+		code_v4_("return 5.1 > 2L;").equals("true");
+		code_v4_("return 2L > 5.1;").equals("false");
+		code_v4_("3L > 4L").equals("false");
+		code_v4_("10L > (3L * 4L)").equals("false");
+		code_v4_("(5L + 5L) > (3L * 4L)").equals("false");
+		code_v4_("(5L + 5L) > 12L").equals("false");
+		code_v4_("3L > 4").equals("false");
+		code_v4_("var a = [2L << 100000000, (2L << 100000000) + 1]; return a[0] < a[1]").equals("true");
+		code_v4_("return 3 > [];").equals("true");
+		code_v4_("return true > [];").equals("true");
+
+		section("Number.operator >=");
+		code_v4_("return 5L >= 2;").equals("true");
+		code_v4_("return 2 >= 5L;").equals("false");
+		code_v4_("return 5.1 >= 2L;").equals("true");
+		code_v4_("return 2L >= 5.1;").equals("false");
+		code_v4_("return 5.1 >= 5L;").equals("true");
+		code_v4_("return 5L >= 5.1;").equals("false");
+		code_v4_("3L >= 4L").equals("false");
+		code_v4_("10L >= (3L * 4L)").equals("false");
+		code_v4_("(5L + 5L) >= (3L * 4L)").equals("false");
+		code_v4_("(5L + 5L) >= 12L").equals("false");
+		code_v4_("3L >= 4").equals("false");
+		code_v4_("return 3 >= [];").equals("true");
+		code_v4_("return true >= [];").equals("true");
+
+		 section("Number.operator \\");
+		 code_v4_("10L \\ 2").equals("5");
+		 code_v4_("10 \\ 4L").equals("2");
+		 code_v4_("2432431L \\ 2313").equals("1051");
+		 code_v4_("var a = 420987 a \\ 546L").equals("771");
+		 code_v4_("420987L \\ 12").equals("35082");
+		 code_v4_("12345678912345L \\ 1234").equals("10004602035");
+//		 code_v4_("12L \\ false").equals("null");
+//		 code_v4_("var a = 13L; a \\ false").exception(ls::vm::Exception::DIVISION_BY_ZERO);
+		 code_v4_("13L \\ true").equals("13");
+		 code_v4_("17 \\ 4L").equals("4");
+		 code_v4_("var a = 10L; a \\ true").equals("10");
+		 code_v4_("var a = 10; a \\ 4L").equals("2");
+//		 code_v4_("14L \\ []").exception(ls::vm::Exception::NO_SUCH_OPERATOR);
+		 code_v4_("67.89 \\ 1L").equals("67");
+		 code_v4_("['', 10L \\ 2]").equals("[\"\", 5]");
+		 code_v4_("['', 10 \\ 2L]").equals("[\"\", 5]");
+
+		 section("Number.operator \\=");
+		 code_v4_("var a = 12 a \\= 5L").equals("2");
+		 code_v4_("var a = 12L a \\= 5").equals("2");
+		 code_v4_("var a = 30L a \\= 4 a").equals("7");
+		 code_v4_("var a = 12L a \\= true a").equals("12");
+//		 code_v4_("var a = 12L a \\= false a").exception(ls::vm::Exception::DIVISION_BY_ZERO);
+//		 code_v4_("var a = 12L a \\= []").exception(ls::vm::Exception::NO_SUCH_OPERATOR);
+//		 code_v4_("var a = 12L a \\= [] a").exception(ls::vm::Exception::NO_SUCH_OPERATOR);
+		 code_v4_("var a = 12L return ['', a \\= 5]").equals("[\"\", 2]");
+		 code_v4_("var a = 12 return ['', a \\= 5L]").equals("[\"\", 2]");
+
+		section("Number.operator &");
+		code_v4_("return 0L & 0L;").equals("0");
+		code_v4_("return 1L & 0;").equals("0");
+		code_v4_("return 1 & 1L;").equals("1");
+		code_v4_("return 5L & 12L;").equals("4");
+		code_v4_("return 87619L & 18431L;").equals("17987");
+		code_v4_("return 87619 & [18431L, ''][0];").equals("17987");
+		code_v4_("var a = 87619L return a &= 18431;").equals("17987");
+		code_v4_("var a = 87619 a &= 18431L return a;").equals("17987");
+
+		section("Number.operator |");
+		code_v4_("return 0L | 0;").equals("0");
+		code_v4_("return 1 | 0L;").equals("1");
+		code_v4_("return 1L | 1L;").equals("1");
+		code_v4_("return 5L | 12L;").equals("13");
+		code_v4_("return [5L, ''][0] | [12, ''][0];").equals("13");
+		code_v4_("return 8945486153454615485641315461564815387619L | 18431145645456165789L;").equals("8945486153...8292884479");
+		code_v4_("var a = 87619L return a |= 18431;").equals("88063");
+		code_v4_("var a = 87619 a |= 18431L return a;").equals("88063");
+		code_v4_("return [87619, ''][0] | 18431L;").equals("88063");
+		// code_v4_("87619$ |= 18431").error(ls::Error::VALUE_MUST_BE_A_LVALUE, {"87619"});
+		code_v4_("var a = 87619L a |= 18431L return a;").equals("88063");
+		code_v4_("var a = 12L return ['', 0 | a];").equals("[\"\", 12]");
+		// code_v4_("[12, 'hello'][1] | 5").exception(ls::vm::Exception::NO_SUCH_OPERATOR);
+
+		section("Number.operator ^");
+		code_v4_("return 0L ^ 0;").equals("0");
+		code_v4_("return 1 ^ 0L;").equals("1");
+		code_v4_("return 1L ^ 1L;").equals("0");
+		code_v4_("return 5L ^ 12;").equals("9");
+		code_v4_("return 871786947865784697168619L ^ 1844789165478467831L;").equals("8717876386...5079771676");
+		code_v4_("return [87619L, ''][0] ^ [18431L, ''][0];").equals("70076");
+		code_v4_("var a = 5L a ^= 2 return a;").equals("7");
+		code_v4_("var a = 87619 return a ^= 18431L;").equals("70076");
+		code_v4_("var a = 87619L a ^= 18431L return a;").equals("70076");
+		code_v4_("return [87619L, ''][0] ^ 18431L;").equals("70076");
+		// code_v4_("87619$ ^= 18431").error(ls::Error::VALUE_MUST_BE_A_LVALUE, {"87619"});
+		code_v4_("var a = 87619L a ^= 18431L return a;").equals("70076");
+		// code_v4_("[12, 'hello'][1] ^ 5").exception(ls::vm::Exception::NO_SUCH_OPERATOR);
+
+		section("Number.operator <<");
+		code_v4_("return 0L << 0;").equals("0");
+		code_v4_("return 1L << 0;").equals("1");
+		code_v4_("return 0L << 0L;").equals("0");
+		code_v4_("return 1L << 1L;").equals("2");
+		code_v4_("return 1 << 0L;").equals("1");
+		code_v4_("return 123456L << 0;").equals("123456");
+		code_v4_("return 0L << 1;").equals("0");
+		code_v4_("return 0L << 12;").equals("0");
+		code_v4_("return 1L << 8;").equals("256");
+		code_v4_("return 123L << 121;").equals("3269900869...8964765696");
+		code_v4_("return [123L, ''][0] << 12;").equals("503808");
+		code_v4_("var a = 123L return a <<= 11;").equals("251904");
+		code_v4_("integer a = 123 return a <<= 11;").equals("251904");
+		code_v4_("big_integer a = 123L return a << 11L;").equals("251904");
+		code_v4_("big_integer a = 123L return a <<= 11;").equals("251904");
+		code_v4_("big_integer a = 123L a <<= 13 return a;").equals("1007616");
+		code_v4_("var a = 123L a <<= 13 return a;").equals("1007616");
+		code_v4_("big_integer a = 123 a <<= 13 return a;").equals("1007616");
+
+		
+		
+		
+		code_v4_("big_integer a = 123 a >>= 1 return a;").equals("61");
+		code_v4_("big_integer a = 123 a >>>= 2 return a;").equals("30");
+		code_v4_("big_integer a = 123 a += 13 return a;").equals("136");
+		code_v4_("big_integer a = 123 a *= 13 return a;").equals("1599");
+		code_v4_("big_integer a = 123 a **= 13 return a;").equals("1474913153...4539944683");
+		code_v4_("big_integer a = 123 a /= 13 return a;").equals("9");
+		code_v4_("big_integer a = 123 a \\= 13 return a;").equals("9");
+		code_v4_("big_integer a = 123 a &= 13 return a;").equals("9");
+		code_v4_("big_integer a = 123 a ^= 13 return a;").equals("118");
+		
+		code_v4_("var a = 123L a >>= 1 return a;").equals("61");
+		code_v4_("var a = 123L a >>>= 2 return a;").equals("30");
+		code_v4_("var a = 123L a += 13 return a;").equals("136");
+		code_v4_("var a = 123L a **= 13 return a;").equals("1474913153...4539944683");
+		code_v4_("var a = 123L a /= 13 return a;").equals("9");
+		
+		code_v4_("var a = 123 a **= 3 return a;").equals("1860867");
+		code_v4_("integer a = 123 a **= 3 return a;").equals("1860867");
+		code_v4_("integer a = 123 a **= 3L return a;").equals("1860867");
+		code_v4_("var a = 123 a >>= 1L return a;").equals("61");
+		code_v4_("var a = 123 a >>= 1 return a;").equals("61");
+		code_v4_("var a = [123L] return a[0] >>>= 1").equals("61");
+		code_v4_("var a = [123] return a[0] >>>= 1").equals("61");
+		code_v4_("Array<integer> a = [123] return a[0] >>>= 1").equals("61");
+		code_v4_("Array<big_integer> a = [123L] return a[0] >>>= 1").equals("61");
+		
+		code_v4_("var a = 123 a -= 13 return a;").equals("110");
+		code_v4_("var a = 123 a -= 13L return a;").equals("110");
+		code_v4_("integer a = 123 a -= 13 return a;").equals("110");
+		code_v4_("big_integer a = 123 a -= 13 return a;").equals("110");
+		
+		code_v4_("big_integer a = 123 a -= 13L return a;").equals("110");
+		code_v4_("integer a = 123 a = a - 13L return a;").equals("110");
+		code_v4_("integer a = 123 a -= 13L return a;").equals("110");
+		code_v4_("integer a = 123 var b = 13L a -= b return a;").equals("110");
+		
+		
+		code_v4_("var a = [123L, ''] return a[0] <<= 13;").equals("1007616");
+		code_v4_("var a = 123L return ['', a <<= 13];").equals("[\"\", 1007616]");
+		// code_v4_("'salut' << 5").exception(ls::vm::Exception::NO_SUCH_OPERATOR);
+
+		section("Number.operator >>");
+		code_v4_("return 0 >> 0L;").equals("0");
+		code_v4_("return 1L >> 0;").equals("1");
+		code_v4_("return 123456L >> 0L;").equals("123456");
+		code_v4_("return 0L >> 1L;").equals("0");
+		code_v4_("return 0L >> 12;").equals("0");
+		code_v4_("return 155L >> 3;").equals("19");
+		code_v4_("return -155L >> 3;").equals("-20");
+		code_v4_("return 12345L >> 8;").equals("48");
+		code_v4_("return 123123123L >> 5;").equals("3847597");
+		code_v4_("return [123123123L, ''][0] >> 5;").equals("3847597");
+		code_v4_("var a = 123123123 return a >>= 6L;").equals("1923798");
+		code_v4_("var a = 123123123L return a >>= 6L;").equals("1923798");
+		code_v4_("big_integer a = 123123123L return a >>= 6L;").equals("1923798");
+		code_v4_("var a = 123123123L a >>= 7 return a;").equals("961899");
+		code_v4_("var a = [123123123L, ''] return a[0] >>= 7;").equals("961899");
+		code_v4_("big_integer a = 12345 return ['', a >>= 8];").equals("[\"\", 48]");
+
+		section("Number.operator >>>");
+		code_v4_("return 0L >>> 0L;").equals("0");
+		code_v4_("return 1L >>> 0;").equals("1");
+		code_v4_("return 123456L >>> 0L;").equals("123456");
+		code_v4_("return 0L >>> 1L;").equals("0");
+		code_v4_("return 0L >>> 12;").equals("0");
+		code_v4_("return 155L >>> 3;").equals("19");
+		code_v4_("return -155L >>> 3;").equals("-20");
+		code_v4_("return 12345L >>> 8;").equals("48");
+		code_v4_("return 123123123L >>> 5;").equals("3847597");
+		code_v4_("return [123123123L, ''][0] >>> 5;").equals("3847597");
+		code_v4_("var a = 123123123L return a >>>= 6L;").equals("1923798");
+		code_v4_("var a = 123123123L return a >>>= 6L;").equals("1923798");
+		code_v4_("big_integer a = 123123123L return a >>>= 6L;").equals("1923798");
+		code_v4_("var a = 123123123L a >>>= 7 return a;").equals("961899");
+		code_v4_("var a = [123123123L, ''] return a[0] >>>= 7;").equals("961899");
+		code_v4_("big_integer a = 12345 return ['', a >>>= 8];").equals("[\"\", 48]");
+		
+		section("Not a statement errors");
+		code_v4_("big_integer a; a; return null;").equals("null");
+		code_v4_("big_integer a; return null;").equals("null");
+		code_v4_("BigInteger a; return null;").equals("null");
+		code_v4_("12L; return null;").equals("null");
+		code_v4_("12 && 5L; return null;").equals("null");
+		code_v4_("12L + 5L; return null;").equals("null");
+		code_v4_("12L - 5; return null;").equals("null");
+		code_v4_("12 * 5L; return null;").equals("null");
+		code_v4_("12L / 5L; return null;").equals("null");
+		code_v4_("12L % 5; return null;").equals("null");
+		code_v4_("12 ** 5L; return null;").equals("null");
+		code_v4_("12L ^ 5; return null;").equals("null");
+		code_v4_("12L & 5L; return null;").equals("null");
+		code_v4_("12L | 5; return null;").equals("null");
+		code_v4_("12 < 5L; return null;").equals("null");
+		code_v4_("12L > 5L; return null;").equals("null");
+		code_v4_("12L <= 5; return null;").equals("null");
+		code_v4_("12 >= 5L; return null;").equals("null");
+		code_v4_("12L == 5L; return null;").equals("null");
+		code_v4_("12L === 5; return null;").equals("null");
+		code_v4_("(12 && 5L); return null;").equals("null");
+		code_v4_("true ? 1L : 2; return null;").equals("null");
+		code_v4_("(true ? 1 : 2L); return null;").equals("null");
+
+		/*
+		* Methods
+		*/
+		section("Number.abs()");
+		code_v4_("return abs(-12L);").equals("12");
+		code_v4_("return abs(-(null - 0L));").equals("0");
+		code_v4_("return abs((null ^ 0L));").equals("0");
+		code_v4_("return abs(~10L);").equals("11");
+		code_v4_("return abs(null);").equals("0.0");
+		code_v4_("big_integer a = -5; var b = [a][0]; return abs(b);").equals("5");
+		code_v4_("return abs(12L);").equals("12");
+		code_v4_("return abs(-164364351523458645648946541564892345665)").equals("1643643515...4892345665");
+		code_v4_("return abs(['a', -15L][1]);").equals("15");
+
+		section("Number.exp()");
+		code_v4_("return exp(0L)").equals("1.0");
+		code_v4_("return exp(1L)").almost(Math.E);
+		code_v4_("return exp(4L)").almost(54.598150033144236204);
+		code_v4_("return exp(['a', 4L][1])").almost(54.598150033144236204);
+		code_v4_("return E ** 5L;").almost(148.413159102576571513);
+
+		section("Number.floor()");
+		code_v4_("return floor(5L);").equals("5");
+		code_v4_("var a = 5L return floor(a);").equals("5");
+		code_v4_("var a = -5L return floor(a);").equals("-5");
+		code_v4_("return floor(['a', -14][1]);").equals("-14");
+		code_v4_("return floor(5);").equals("5");
+
+		section("Number.round()");
+		code_v4_("return round(5L);").equals("5");
+		code_v4_("var a = 5L return round(a);").equals("5");
+		code_v4_("var a = -5L return round(a);").equals("-5");
+		code_v4_("return round(['a', -14][1]);").equals("-14");
+		code_v4_("return round(5);").equals("5");
+
+		section("Number.ceil()");
+		code_v4_("return ceil(5L);").equals("5");
+		code_v4_("var a = 5L return ceil(a);").equals("5");
+		code_v4_("var a = -5L return ceil(a);").equals("-5");
+		code_v4_("return ceil(['a', -14][1]);").equals("-14");
+		code_v4_("return ceil(5);").equals("5");
+
+		section("Number.max()");
+		code_v4_("return max(8, 5L)").equals("8");
+		code_v4_("return max(8L, 88)").equals("88");
+		code_v4_("return max(5L, 12L);").equals("12");
+		code_v4_("return max(5.0, 12L);").equals("12.0");
+		code_v4_("return max(5L, 12.0);").equals("12.0");
+		code_v4_("return max(75.7, 12L);").equals("75.7");
+		code_v4_("return max(5.0, 5L);").equals("5.0");
+		code_v4_("return max(5L, 12.451);").almost(12.451);
+		code_v4_("return max([5L, 'a'][0], 4);").equals("5");
+		code_v4_("return max([5, 'a'][0], 76L);").equals("76");
+		code_v4_("return max(4, [5L, 'a'][0]);").equals("5");
+		code_v4_("return max(77L, [5.3, 'a'][0]);").equals("77.0");
+		code_v4_("return max([55L, 'a'][0], [5, 'a'][0]);").equals("55");
+		code_v4_("var a = 0.8 return max(0L, a)").equals("0.8");
+		code_v4_("big_integer a = 1 return max(0, a)").equals("1");
+		code_v4_("real value = 5 value *= max(1L, 1.1) return value").equals("5.5");
+		code_v4_("big_integer value = 5 value *= max(1, 2L) return value").equals("10");
+		
+		section("Number.min()");
+		code_v4_("return min(8, 5L)").equals("5");
+		code_v4_("return min(8L, 88)").equals("8");
+		code_v4_("return min(5L, 12L);").equals("5");
+		code_v4_("return min(5.0, 12L);").equals("5.0");
+		code_v4_("return min(5L, 12.0);").equals("5.0");
+		code_v4_("return min(75.7, 12L);").equals("12.0");
+		code_v4_("return min(5.0, 5L);").equals("5.0");
+		code_v4_("return min(5L, 12.451);").equals("5.0");
+		code_v4_("return min([5L, 'a'][0], 4);").equals("4");
+		code_v4_("return min([5, 'a'][0], 76L);").equals("5");
+		code_v4_("return min(4, [5L, 'a'][0]);").equals("4");
+		code_v4_("return min(77L, [5.3, 'a'][0]);").equals("5.3");
+		code_v4_("return min([55L, 'a'][0], [5, 'a'][0]);").equals("5");
+		code_v4_("var a = 0.8 return min(0L, a)").equals("0.0");
+		code_v4_("big_integer a = 1 return min(0, a)").equals("0");
+		code_v4_("real value = 5 value *= min(1L, 1.1) return value").equals("5.0");
+		code_v4_("big_integer value = 5 value *= min(1, 2L) return value").equals("5");
+		
+		section("Number.cos()");
+		code_v4_("return cos(0L)").equals("1.0");
+
+		section("Number.acos()");
+		code_v4_("return acos(1L)").equals("0.0");
+		
+		section("Number.sin()");
+		code_v4_("return sin(0L)").equals("0.0");
+
+		section("Number.tan()");
+		code_v4_("return tan(0L)").equals("0.0");
+		
+		section("Number.asin()");
+		code_v4_("return asin(0L)").equals("0.0");
+
+		section("Number.atan()");
+		code_v4_("return atan(1L)").equals("0.7853981633974483");
+
+		section("Number.atan2()");
+		code_v4_("return atan2(1L, 1L)").equals("0.7853981633974483");
+
+		section("Number.cbrt()");
+		code_v4_("return cbrt(125L)").almost(5.0);
+
+		section("Number.hypot");
+		code_v4_("return hypot(3, 4)").equals("5.0");
+
+		section("Number.signum");
+		code_v4_("return signum(0L)").equals("0");
+		code_v4_("return signum(12L)").equals("1");
+		code_v4_("return signum(-17L)").equals("-1");
+		code_v4_("return signum(-12L)").equals("-1");
+		code_v4_("return signum(85L)").equals("1");
+
+		// sqrt, cbrt, log, log2, log10, exp, etc do not exist in BigInteger, so it falls back to int/double
+		section("Number.sqrt");
+		code_v4_("return sqrt(2L)").equals("1.4142135623730951");
+		
+		section("Number.toDegrees");
+		code_v4_("return toDegrees(0L)").equals("0.0");
+
+		section("Number.toRadians");
+		code_v4_("return toRadians(0L)").equals("0.0");
+
+		section("Number.log");
+		code_v4_("return log(1L)").equals("0.0");
+
+		section("Number.log10");
+		code_v4_("return log10(10L)").equals("1.0");
+
+		section("Number.pow");
+		code_v4_("return pow(5L, 3)").equals("125");
+		code_v4_("return pow(2, 10L)").equals("1024");
+		code_v4_("pow([10L, ''][0], 5)").equals("100000");
+		code_v4_("pow(3000L, 3L)").equals("27000000000");
+		code_v4_("return pow(2L, 70)").equals("1180591620...7411303424");
+		code_v4_("pow(5L, -2)").equals("0.04");
+		
+		section("Number.rand()");
+		code_v4_("var a = randInt(2067L, 2070L) return a >= 2067 and a < 2070").equals("true");
+		code_v4_("var a = randReal(500L, 510L) return a >= 500 and a < 510").equals("true");
+
+		section("Number.setBit()");
+		code_v4_("setBit(3L, 70)").equals("1180591620...7411303427");
+		code_v4_("return setBit(3L, 70)").equals("1180591620...7411303427");
+		code_v4_("return setBit(3L, 70, true)").equals("1180591620...7411303427");
+		code_v4_("setBit(3L, 70L, true)").equals("1180591620...7411303427");
+		code_v4_("setBit(3L, 70L, 1)").equals("1180591620...7411303427");
+		code_v4_("setBit(3L, 70L)").equals("1180591620...7411303427");
+		code_v4_("setBit(3L, 70, false)").equals("3");
+		code_v4_("setBit(setBit(3L, 70), 70, false)").equals("3");
+		code_v4_("setBit(setBit(3L, 70), 1, 0)").equals("1180591620...7411303425");
+		code_v4_("setBit(3, 2, true)").equals("7");
+		code_v4_("return setBit(3, 2)").equals("7");
+		code_v4_("return setBit(3, 1, false)").equals("1");
+		code_v4_("return setBit(3, 1L, 0)").equals("1");
+		code_v4_("return setBit(3, 1, true)").equals("3");
+		
+		section("Number.testBit()");
+		code_v4_("testBit(1180591620717411303427, 70)").equals("true");
+		code_v4_("testBit(1180591620717411303427L, 69)").equals("false");
+		code_v4_("testBit(1180591620717411303427L, 1L)").equals("true");
+		code_v4_("testBit(3, 1)").equals("true");
+		code_v4_("testBit(3, 0L)").equals("true");
+		code_v4_("testBit(3, 10)").equals("false");
+		
+		section("Number.bitLength()");
+		code_v4_("bitLength(1180591620717411303427)").equals("71");
+		code_v4_("bitLength(-1180591620717411303427L)").equals("71");
+		code_v4_("bitLength(3)").equals("2");
+		code_v4_("bitLength(-3)").equals("64");
+
+		section("Number.bitCount()");
+		code_v4_("return bitCount(0L)").equals("0");
+		code_v4_("return bitCount(0b11001110011L)").equals("7");
+		code_v4_("return bitCount(0b111100111001111L)").equals("11");
+		code_v4_("return bitCount(0xffL)").equals("8");
+
+		section("Number.trailingZeros()");
+		code_v4_("return trailingZeros(0L)").equals("-1");
+		code_v4_("return trailingZeros(0b00001100110000L)").equals("4");
+		code_v4_("return trailingZeros(0b100000000000L)").equals("11");
+		code_v4_("return trailingZeros(0xff00L)").equals("8");
+
+		section("Number.leadingZeros()"); // undefined for bigint, so it should be casted to int
+		code_v4_("return leadingZeros([0L][0])").equals("64");
+		code_v4_("return leadingZeros([0b0000110011L, ''][0])").equals("58");
+
+		
+		// not implemented for bigint (currently falls back to integers)
+		section("Number.bitReverse()");
+		code_v4_("return binString(bitReverse(0L))").equals("\"0\"");
+		code_v4_("return binString(bitReverse(0b0000110011L))").equals("\"1100110000000000000000000000000000000000000000000000000000000000\"");
+		
+		section("Number.byteReverse()");
+		code_v4_("return hexString(byteReverse(0L))").equals("\"0\"");
+		code_v4_("return hexString(byteReverse(0xaabbccddeeffL))").equals("\"ffeeddccbbaa0000\"");
+
+		section("Number.binString()");
+		code_v4_("return binString(0L)").equals("\"0\"");
+		code_v4_("return binString(0b0000110011L)").equals("\"110011\"");
+		code_v4_("return binString(0b11001111000111001011101101110000110011L)").equals("\"11001111000111001011101101110000110011\"");
+		code_v4_("return binString(2L ** 70)").equals("\"10000000000000000000000000000000000000000000000000000000000000000000000\"");
+
+
+		section("Number.hexString()");
+		code_v4_("return hexString(0L)").equals("\"0\"");
+		code_v4_("return hexString(0xAABBCCDDEEFFL)").equals("\"aabbccddeeff\"");
+		code_v4_("return hexString(0xABCDEF00FEDCBAL)").equals("\"abcdef00fedcba\"");
+		code_v4_("return hexString(0xAAAAAAA0000000L)").equals("\"aaaaaaa0000000\"");
+		code_v4_("return hexString(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFL)").equals("\"ffffffffffffffffffffffffffffffffffffffff\"");
+
+		// not implemented for bigint (currently falls back to integers)
+		section("Number.isPermutation");
+		code_v4_("return isPermutation(0L, 0L)").equals("true");
+		code_v4_("return isPermutation(1, 0L)").equals("false");
+		code_v4_("return isPermutation(12345678L, 51762384)").equals("true");
+		code_v4_("return isPermutation(11112222L, 22221111L)").equals("true");
+		code_v4_("return isPermutation(123456, 12345678L)").equals("false");
+
+		section("Operator ==");
+		code_v4_("return false == 0L").equals("false");
+		code_v4_("return true == 1L").equals("false");
+		code_v4_("return false != 0L").equals("true");
+		code_v4_("return true != 1L").equals("true");
+		code_v4_("return false == ''").equals("false");
+		code_v4_("return false == '0L'").equals("false");
+		code_v4_("return false == []").equals("false");
+		code_v4_("return false == [0L]").equals("false");
+		code_v4_("return true == 12L").equals("false");
+		code_v4_("return true == '1L'").equals("false");
+		code_v4_("return true == '12L'").equals("false");
+		code_v4_("return true == [1L]").equals("false");
+		code_v4_("return true == [12L]").equals("false");
+		code_v4_("return true == [1L, 2L, 3L]").equals("false");
+
+		code_v4_("return 0L == false").equals("false");
+		code_v4_("return 0L == 0").equals("true");
+		code_v4_("return 0 == 0L").equals("true");
+		code_v4_("return 0L == 0L").equals("true");
+		code_v4_("return 0L == ''").equals("false");
+		code_v4_("return 0L == '0'").equals("false");
+		code_v4_("return 0L == '0L'").equals("false");
+		code_v4_("return 0L == 'false'").equals("false");
+		code_v4_("return 0L == []").equals("false");
+		code_v4_("return 0L == [0L]").equals("false");
+		code_v4_("return 0L == [0]").equals("false");
+		code_v4_("return 0L != null").equals("true");
+
+		code_v4_("return 1L == true").equals("false");
+		code_v4_("return 1L == '1'").equals("false");
+		code_v4_("return 1L == '1L'").equals("false");
+		code_v4_("return 1 == '1L'").equals("false");
+		code_v4_("return 1L == 'true'").equals("false");
+		code_v4_("return 1L == 'lama'").equals("false");
+		code_v4_("return 1L == [1]").equals("false");
+		code_v4_("return 1L == [1L]").equals("false");
+		code_v4_("return 1 == [1L]").equals("false");
+		code_v4_("return 1L == 2").equals("false");
+		code_v4_("return 1L == 2L").equals("false");
+		code_v4_("return 1 == 2L").equals("false");
+		code_v4_("return 3.0 == 3").equals("true");
+		code_v4_("return 3.0 == 3L").equals("true");
+		code_v4_("return 3 == 3L").equals("true");
+		code_v4_("return 3L == 3").equals("true");
+		code_v4_("return 3L == 3.0").equals("true");
+
+		code_v4_("return 12L == true").equals("false");
+		code_v4_("return -1L == -5").equals("false");
+		code_v4_("return -1L == -5L").equals("false");
+		code_v4_("return -1 == -5L").equals("false");
+		code_v4_("return 50L == 50L").equals("true");
+		code_v4_("return 5L == 5L").equals("true");
+		code_v4_("return 45L == 5L").equals("false");
+		code_v4_("return 10L == '10'").equals("false");
+		code_v4_("return 10L == '15'").equals("false");
+		code_v4_("return 10L == '15'").equals("false");
+		code_v4_("return 10L == 10.87").equals("false");
+		code_v4_("return 10.87 == 10L").equals("false");
+		code_v4_("return 12L == 'true'").equals("false");
+		code_v4_("return 2L == 'false'").equals("false");
+		code_v4_("return 12L == [12]").equals("false");
+		code_v4_("return 12L == [12L]").equals("false");
+		code_v4_("return 12 == [12L]").equals("false");
+
+		code_v4_("return [] == 0L").equals("false");
+		code_v4_("return [0L] == [0]").equals("true");
+		code_v4_("return [0L] == [0L]").equals("true");
+		code_v4_("return [0L] == [0L]").equals("true");
+		code_v4_("return [0L, 1] == [0, 1L]").equals("true");
+		code_v4_("return [0L, 1] == [0L]").equals("false");
+
+		String[] values1 = new String[] { "false", "true", "0L", "1L", "12L", "''", "'0'", "'1'", "'12'", "'lama'", "'true'", "'false'",
+			"[]", "[0L]", "[1L]", "[12L]", "[1L,2L,3L]", "null" };
+
+		for (int i = 0; i < values1.length; i++) {
+			for (int j = 0; j < values1.length; j++) {
+				code_v4_("return " + values1[i] + " == " + values1[j]).equals(String.valueOf(i == j));
+			}
+		}
+
+		section("Other operators");
+		code_v4_("var sum = 1L, ops = 10 return sum < ops * 0.95 || sum > ops").equals("true");
+		code_v4_("var sum = 9.8, ops = 10L return sum < ops * 0.95 || sum > ops").equals("false");
+		code_v4_("var sum = 98L var ops = 100L return sum < ops * 0.95 || sum > ops").equals("false");
+		code_v4_("var sum = 98L var ops = 100 if (sum < ops * 0.95 || sum > ops) {}").equals("null");
+		code_v4_("var sum = 1 var ops = 10L if (sum < ops * 0.95 || sum > ops) {} return null").equals("null");
+		code_v4_("return !null == 50L").equals("false");
+
+		section("Operator ===");
+		Object[] values = new Object[] { "0L", "1L",
+			"12L", "13L", "false",
+			"true", "null", "'true'",
+			"'false'", "'12'",
+			"'lama'",
+			"[]", "['12L']" };
+
+		for (int i = 0; i < values.length; i++) {
+			for (int j = 0; j < values.length; j++) {
+				code_v4_("return " + values[i] + " === " + values[j]).equals(String.valueOf(i == j));
+			}
+		}
+		code_v4_("return 1L === 1.0").equals("true");
+		code_v4_("return 12L === 12.0").equals("true");
+
+		code_v4_("var a = 1; var result = -10L + (1- (a-1)); return result").equals("-9");
+		code_v4_("var a = 1L; var result = 0; result = -10 + (1L- (a-1)); return result").equals("-9");
+		code_v4_("var a = 1; big_integer result = 0; result = -10 + a; return result").equals("-9");
+		code_v4_("var a = 1; big_integer result = 0; result = -10 >> a; return result").equals("-5");
+		code_v4_("var a = 1; big_integer result = 1; result >>= -10 << a; return result").equals("1048576");
+		code_v4_("var a = 1; big_integer result = 0; result = -10 + (1- (a-1)); return result").equals("-9");
+		code_v4_("big_integer a = 1; var result = 0; result = -10 + (1- (a-1)); return result").equals("-9");
+
+		code_v4_("return null < 3L").equals("true");
+		code_v4_("var a = null return a < 3L").equals("true");
+		code_v4_("return true < 10L").equals("true");
+		code_v4_("return false < 10L").equals("true");
+		code_v4_("return 10L < true").equals("false");
+		code_v4_("return 10L < false").equals("false");
+		code_v4_("return 10L > true").equals("true");
+		code_v4_("return 10L > false").equals("true");
+		code_v4_("return true > 10L").equals("false");
+		code_v4_("return false > 10L").equals("false");
+
+		code_v4_("var a = 20L if (15 > a > 11L) { return true } return false").equals("false");
+		code_v4_("var a = 20 if (15L > a > 11) { return true } return false").equals("false");
+		code_v4_("var a = 20 if (15 > a as BigInteger > 11) { return true } return false").equals("false");
+		code_v4_("var a = \"test\" if (15 > a as BigInteger > 11) { return true } return false").error(Error.IMPOSSIBLE_CAST);
+		code_v4_("return 15L > 14 > 11 and 150 < 200 < 250L").equals("false");
+		code_v4_("return 15 > 10L > 11 and 150 < 200L < 250").equals("false");
+		code_v4_("return 15 > 14 > 11L and 150L < 100 < 250").equals("false");
+		code_v4_("return 15L > 10L > 11L and 150L < 100L < 250L").equals("false");
+
+		section("Operator +");
+		code_v4_("return false + 1L").equals("1");
+		code_v4_("return 1L + false").equals("1");
+		code_v4_("return true + 1L").equals("2");
+		code_v4_("return 1L + true").equals("2");
+
+		section("Comparison always false");
+		code_v4_("5L == true").warning(Error.COMPARISON_ALWAYS_FALSE);
+		code_v4_("Array == 12L").warning(Error.COMPARISON_ALWAYS_FALSE);
+
+		section("Comparison always true");
+		code_v4_("5L != true").warning(Error.COMPARISON_ALWAYS_TRUE);
+		code_v4_("Array != 12L").warning(Error.COMPARISON_ALWAYS_TRUE);
+
+		section("Unknown operator");
+		code_v4_("'salut' - 2L").warning(Error.UNKNOWN_OPERATOR);
+		code_v4_("2L / [1L, 2, 3]").warning(Error.UNKNOWN_OPERATOR);
+		code_v4_("{} % 5L").warning(Error.UNKNOWN_OPERATOR);
+
+		header("Variables");
+		code_v4_("var a = 2L return a").equals("2");
+		code_v4_("big_integer a = 2L return a").equals("2");
+		code_v4_("big_integer a = 2 return a").equals("2");
+		code_v4_("var a, b, c = 3L return c").equals("3");
+		code_v4_("big_integer a, b, c = 3 return c").equals("3");
+		code_v4_("var a = 1L, b = 2, c = 3L return c").equals("3");
+		code_v4_("big_integer a = 1, b = 2, c return c").equals("0");
+		code_v4_("big_integer a return a").equals("0");
+		code_v4_("var a a = 12L return a").equals("12");
+		code_v4_("big_integer a a = 12 return a").equals("12");
+		code_v4_("var a = 5L a = 13 return a").equals("13");
+		code_v4_("var a = 1 var b = (a = 12L) return b").equals("12");
+		code_v4_("big_integer a = 2 return [a = 10]").equals("[10]");
+		code_v4_("var a = 2 return ['a', a = 10L]").equals("[\"a\", 10]");
+
+		section("typeOf()");
+		// Test nombre
+		code_v4_("return typeOf(255L)").equals(String.valueOf(LeekConstants.TYPE_NUMBER.getIntValue()));
+		code_v4_("return typeOf(255.8 + 1L)").equals(String.valueOf(LeekConstants.TYPE_NUMBER.getIntValue()));
+		// Test string
+		code_v4_("return typeOf('coucou' + 1L)").equals(String.valueOf(LeekConstants.TYPE_STRING.getIntValue()));
+		// Test boolean
+		code_v4_("return typeOf(false + 1L)").equals(String.valueOf(LeekConstants.TYPE_NUMBER.getIntValue()));
+		// Test array
+		code_v4_("return typeOf([1L,false])").equals(String.valueOf(LeekConstants.TYPE_ARRAY.getIntValue()));
+		// Test fonction
+		code_v4_("return typeOf(function(){ return 1L; })").equals(String.valueOf(LeekConstants.TYPE_FUNCTION.getIntValue()));
+		// Test null
+		code_v4_("return typeOf(null + 1L)").equals(String.valueOf(LeekConstants.TYPE_NUMBER.getIntValue()));
+		// Test piège
+		code_v4_("return typeOf(function(){ return 4L; }())").equals(String.valueOf(LeekConstants.TYPE_NUMBER.getIntValue()));
+		code_v4_("return typeOf(<1L, 2, 3>)").equals(String.valueOf(LeekConstants.TYPE_SET.getIntValue()));
+		code_v4_("return typeOf([1L..10L])").equals(String.valueOf(LeekConstants.TYPE_INTERVAL.getIntValue()));
+
+		section("Type changes");
+		code_v4_("var a return a = 12L").equals("12");
+		code_v4_("var a a = 12L return a").equals("12");
+		code_v4_("var a = 12L return a = 'a'").equals("\"a\"");
+		code_strict("var a = 2L return a = 'hello'").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("big_integer a = 2 return a = 'hello'").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("any a = 2L return a = 'hello'").equals("\"hello\"");
+		code_v4_("var a = 'hello' return a = 2L").equals("2");
+		code_strict("var a = 'hello' return a = 2L").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("any a = 'hello' return a = 2L").equals("2");
+		code_v4_("var a = 2L a = 'hello' return a").equals("\"hello\"");
+		code_strict("var a = 2L a = 'hello' return a").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("big_integer a = 2L a = 'hello' return a").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("any a = 2L a = 'hello' return a").equals("\"hello\"");
+		code_v4_("var a = 2L a = [1L, 2L] return a").equals("[1, 2]");
+		code_strict("var a = 2L a = [1L, 2] return a").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("big_integer a = 2L a = [1L, 2] return a").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("any a = 2L a = [1, 2L] return a").equals("[1, 2]");
+		code_v4_("var a = 5L a = {} return a").equals("{}");
+		code_strict_v4_("var a = 5L a = {} return a").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict_v4_("big_integer a = 5L a = {} return a").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict_v4_("any a = 5L a = {} return a").equals("{}");
+		code_v4_("var a = 5.5 return a = 2L").equals("2");
+		code_v4_("var a = 5.5 a = 1000L").equals("1000");
+		code_v4_("var a = 5.5 a = 2L ** 100").equals("1267650600...6703205376");
+		code_v4_("var a = 2L return a = 5").equals("5");
+		code_v4_("var a = [] a = 5L").equals("5");
+
+
+		section("Assignments");
+		code_v4_("var b = 5L if (1) { b = 'salut' } return b").equals("\"salut\"");
+		code_strict("var b = 5L if (1L) { b = 'salut' } return b").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("any b = 5L if (1) { b = 'salut' } return b").equals("\"salut\"");
+		code_strict("big_integer b = 5L if (1) { b = 'salut' } return b").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_v4_("var b = 5L if (0) { b = 'salut' } return b").equals("5");
+		code_strict("var b = 5L if (0) { b = 'salut' } return b").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_strict("any b = 5L if (0L) { b = 'salut' } return b").equals("5");
+		code_strict("big_integer b = 5 if (0L) { b = 'salut' } return b").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_v4_("var a = 12L if (1) { a = 5L a++ } else { a = 3L } return a").equals("6");
+		code_v4_("var a = 12L if (0) { a = 5L a++ } else { a = 5.5 } return a").equals("5.5");
+		code_v4_("var b = 5L if (1) {} else { b = 'salut' } return b").equals("5");
+		code_strict("any b = 5L if (1) {} else { b = 'salut' } return b").equals("5");
+		code_strict("big_integer b = 5 if (1) {} else { b = 'salut' } return b").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_v4_("var b = 5L if (0) {} else { b = 'salut' } return b").equals("\"salut\"");
+		code_strict("any b = 5L if (0) {} else { b = 'salut' } return b").equals("\"salut\"");
+		code_strict("big_integer b = 5L if (0) {} else { b = 'salut' } return b").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_v4_("var x = 5L if (true) if (true) x = 'a' return x").equals("\"a\"");
+		code_strict("any x = 5L if (true) if (true) x = 'a' return x").equals("\"a\"");
+		code_v4_("var x = 5L if (true) if (true) if (true) if (true) if (true) x = 'a' return x").equals("\"a\"");
+		code_strict("any x = 5L if (true) if (true) if (true) if (true) if (true) x = 'a' return x").equals("\"a\"");
+		code_v4_("var y if (false) { if (true) {;} else { y = 2L } } else { y = 5L } return y").equals("5");
+		code_v4_("PI = PI + 12L; return PI").error(Error.CANT_ASSIGN_VALUE);
+		code_v4_("var PI = 3L return PI").equals("3");
+		code_v4_("var a = 2L var b = 5 var c = 7L; a = b = c return [a, b, c]").equals("[7, 7, 7]");
+
+		section("Assignments with +=");
+		code_v4_("var a = 10L a += 0.5 return a").equals("10");
+		code_v4_("var a = 10L a = 0.5 + a return a").equals("10");
+		code_strict_v2_("var a = 10L a += 0.5 return a").equals("10");
+		code_strict_v2_("var a = 10L a += 4.5 return a").equals("14");
+
+		section("number()");
+		code_v4_("return number(12L)").equals("12");
+		code_v4_("return number('12L')").equals("12");
+		code_v4_("return number('112x32')").equals("0");
+		code_v4_("return number('11.2x32')").equals("0");
+		code_v4_("return number(1267650600228229401496703205376)").equals("1267650600...6703205376");
+		code_v4_("return number('1267650600228229401496703205376')").equals("1267650600...6703205376");
+
+		section("Variables and types");
+		code_v4_("real a = 1.1 big_integer b = a return b").equals("1");
+		code_v4_("big_integer a = 1 integer b = a return b").equals("1");
+		code_v4_("integer a = 1 big_integer b = a return b").equals("1");
+		code_v4_("integer|big_integer|real a = 1.999; return a").equals("1.999");
+		code_v4_("integer|real a = 1.999; big_integer b = a; return b").equals("1");
+		code_v4_("big_integer|real a = 1.999; integer b = a; return b").equals("1");
+		code_v4_("integer|big_integer a = 1; real b = a; return b").equals("1.0");
+		code_v4_("real|big_integer a = 1L; integer b = a; return b").equals("1");
+		code_v4_("integer a = 1 big_integer b = 2 a -= b return a").equals("-1");
+		code_v4_("integer a = 1 any b = 2L a -= b return a").equals("-1");
+		code_v4_("integer a = 1 big_integer b = 2 a += b return a").equals("3");
+		code_v4_("integer a = 1 any b = 2L a += b return a").equals("3");
+		
+		section("Objects");
+		code_v4_("return BigInteger").equals("<class BigInteger>");
+		code_v4_("class A { big_integer x = 10 m() { return ++this.x } } return new A().m()").equals("11");
+		code_v4_("class A { big_integer x = 10 m() { return this.x++ } } return new A().m()").equals("10");
+		code_v4_("class A { big_integer x = 10 m() { return this.x-- } } return new A().m()").equals("10");
+		code_v4_("class A { big_integer x = 10 m() { return --this.x } } return new A().m()").equals("9");
+		code_v4_("class A { big_integer x = 10 m() { return --x } } return new A().m()").equals("9");
+		code_v4_("class A { big_integer x = 10 m() { return ++x } } return new A().m()").equals("11");
+		code_v4_("class A { big_integer x = 10 m() { return x-- } } return new A().m()").equals("10");
+		code_v4_("class A { big_integer x = 10 m() { return x++ } } return new A().m()").equals("10");
+		code_v4_("class A { big_integer x = 10 m(y) { this.x = y return this } } return new A().m(50L)").equals("A {x: 50}");
+		code_v4_("class A { big_integer x = 10 m(y) { this.x = y return this } } return new A().m(50.0)").equals("A {x: 50}");
+		code_v4_("class A { any x = 10 m(y) { this.x = y return this } } return new A().m(50L)").equals("A {x: 50}");
+		code_v4_("class A { x = 10L m(y) { this.x = y return this } } return new A().m(50)").equals("A {x: 50}");
+		code_v4_("class A { integer x = 10 m(y) { this.x = y return this } } return new A().m(50L)").equals("A {x: 50}");
+		code_v4_("class A { integer x = 10 m(y) { x -= y return x } } return new A().m(2L)").equals("8");
+		code_v4_("class A { big_integer x = 10L m(y) { this.x += y return this } } return new A().m(50)").equals("A {x: 60}");
+		code_v4_("class A { big_integer x = 2 / 2 m(y) { this.x += y return this } } return new A().m(50)").equals("A {x: 51}");
+		code_v4_("class A { big_integer x = 10 m(y) { this.x += y return this } } return new A().m(50)").equals("A {x: 60}");
+		code_v4_("class A { big_integer x = 10 m(y) { this.x -= y return this } } return new A().m(50)").equals("A {x: -40}");
+		code_v4_("class A { x = 10L m(y) { this.x -= y return this } } return new A().m(50)").equals("A {x: -40}");
+		code_v4_("class A { real x = 10 m(y) { this.x -= y return this } } return new A().m(50L)").equals("A {x: -40.0}");
+		code_v4_("class A { real x = 10 m(real y) { this.x -= y return this } } return new A().m(50L)").equals("A {x: -40.0}");
+		code_v4_("class A { big_integer x = 10 m(y) { this.x -= y return this } } return new A().m(50)").equals("A {x: -40}");
+		code_v4_("class A { big_integer x = 10 m(y) { this.x *= y return this } } return new A().m(50)").equals("A {x: 500}");
+		code_v4_("class A { big_integer x = 10 m(y) { this.x /= y return this } } return new A().m(4)").equals("A {x: 2}");
+		
+		// static
+		code_v4_("class A { static x = 10 m(y) { x -= y return x } } return new A().m(5L)").equals("5");
+		code_v4_("class A { static integer x = 10 m(y) { x -= y return x } } return new A().m(5)").equals("5");
+		code_v4_("class A { static big_integer x = 10L m(y) { x -= y return x } } return new A().m(5)").equals("5");
+		code_v4_("class A { static big_integer x = 10 m(y) { x -= y return x } } return new A().m(5)").equals("5");
+		code_strict_v4_("class A { static real x = 10 m(y) { x -= y return x } } return new A().m(5)").equals("5.0");
+		code_strict_v4_("class A { static real x = \"test\" m() { return x } } return new A().m()").error(Error.ASSIGNMENT_INCOMPATIBLE_TYPE);
+		code_v4_("class A { static integer x = 10 m(y) { x -= y return x } } return new A().m(5L)").equals("5");
+		code_v4_("class A { static integer x = 10 m(y) { x -= y return x } } return new A().m(5L) instanceof Integer").equals("true");
+		code_v4_("class A { static integer x = 10 m(y) { return x - y } } return new A().m(5L) instanceof BigInteger").equals("true");
+	
+		// default args
+		code_v4_("class A { static integer x = 10 m(y = 5L) { x -= y return x } } return new A().m()").equals("5");
+		code_v4_("class A { static integer x = 10 m(y = 5L) { x -= y return x } } return new A().m() instanceof Integer").equals("true");
+		code_v4_("class A { static integer x = 10 m(y = 5L) { x -= y return x } } return new A().m(2L)").equals("8");
+		code_v4_("class A { integer x = 10 m(y = 5L) { x -= y return x } } return new A().m()").equals("5");
+		code_v4_("class A { integer x = 10 m(y = 5L) { x -= y return x } } return new A().m(2L)").equals("8");
+		code_v4_("class A { static big_integer x = 10 m(y = 5) { x -= y return x } } return new A().m(2L)").equals("8");
+		code_v4_("class A { static big_integer x = 10 m(y = 5) { x -= y return x } } return new A().m()").equals("5");
+		code_v4_("class A { big_integer x = 10 m(y = 5) { x -= y return x } } return new A().m()").equals("5");
+		code_v4_("class A { big_integer x = 10L m(y = 5) { x -= y return x } } return new A().m(2L)").equals("8");
+		
+		// static functions
+		code_v4_("class A { static integer x = 10 static m(y = 5L) { x -= y return x } } return A.m()").equals("5");
+		code_v4_("class A { static integer x = 10 static m(y = 5L) { x -= y return x } } return A.m() instanceof Integer").equals("true");
+		code_v4_("class A { static integer x = 10 static m(y = 5L) { x -= y return x } } return A.m(2L)").equals("8");
+		code_v4_("class A { static integer x = 10 static m(y = 5L) { x -= y return x } } return A.m()").equals("5");
+		code_v4_("class A { static integer x = 10 static m(y = 5L) { x -= y return x } } return A.m(2L)").equals("8");
+		code_v4_("class A { static big_integer x = 10 static m(y = 5) { x -= y return x } } return A.m(2L)").equals("8");
+		code_v4_("class A { static big_integer x = 10 static m(y = 5) { x -= y return x } } return A.m()").equals("5");
+		code_v4_("class A { static big_integer x = 10 static m(y = 5) { x -= y return x } } return A.m()").equals("5");
+		code_v4_("class A { static big_integer x = 10L static m(y = 5) { x -= y return x } } return A.m(2L)").equals("8");
+		code_v4_("class A { static big_integer x = 10L static m() { x += 1 return x } } return A.m()").equals("11");
+		code_v4_("class A { static big_integer x = 10L static m() { ++x return x } } return A.m()").equals("11");
+		
+		// final
+		code_v4_("class A { static final integer x = 10 static m() { return x + 0L} } return A.m()").equals("10");
+		code_v4_("class A { static final integer x = 10 static m(y = 5L) { return x - y } } return A.m()").equals("5");
+		code_v4_("class A { final integer x = 10 m(y = 5L) { return x } } return new A().m()").equals("10");
+		code_v4_("class A { static final integer x = 10 static m() { return x - 5L } } return A.m() instanceof BigInteger").equals("true");
+		code_v4_("class A { static final big_integer x = 10 static m(y = 5L) { return x - y } } return A.m()").equals("5");
+		code_v4_("class A { final big_integer x = 10 m(y = 5L) { return x } } return new A().m()").equals("10");
+		code_v4_("class A { static final big_integer x = 10 static m() { return x - 5 } } return A.m() instanceof BigInteger").equals("true");
+		
+		section("Globals");
+		code_v4_("global x = 10 return x").equals("10");
+		code_v4_("global x = 10L return x").equals("10");
+		code_v4_("global big_integer x = 10L return x").equals("10");
+		code_v4_("global big_integer x = 10 return x").equals("10");
+		code_v4_("global big_integer x; x = 10 return x").equals("10");
+		code_v4_("global big_integer x = 10; x-- return x").equals("9");
+		code_v4_("global big_integer x = 10; return --x").equals("9");
+		code_v4_("global big_integer x = 10; x++ return x").equals("11");
+		code_v4_("global big_integer x = 10; return ++x").equals("11");
+		code_v4_("global big_integer x = 10; return x += 1").equals("11");
+		code_v4_("global x = 10 - 1L return x").equals("9");
+		code_v4_("global x = 10 - 1L return x instanceof BigInteger").equals("true");
+		
+		section("String");
+		// print a very big number
+		code_v4_("string((12345678912L * (10L**1000)) + 12345678987654321)").equals("\"1234567891...8987654321\"");
+		code_v4_("(123456789L * (10L**1000)) + 987654321").equals("1234567890...0987654321");
+		code_v4_("9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999").equals("9999999999...9999999999");
+		code_v4_("9999999999999999999999999999999999999999999999999999999999999223372036854775807").equals("9999999999...6854775807");
+		code_v4_("-0xffffffffffffffffffffffffffffffffL").equals("-3402823669...1768211455");
+		code_v4_("-0xffffffffffL").equals("-1099511627775");
+		code_v4_("-99999999999999999").equals("-99999999999999999");
+		code_v4_("-999999999").equals("-999999999");
+		code_v4_("10L**100000 + 1").equals("1000000000...0000000001");
+		
+		section("JSON");
+		code_v4_("var m = [5L, {L:5L}, ['L':5L], [5L]] return m").equals("[5, {L: 5}, [\"L\" : 5], [5]]");
+	}
+}

--- a/src/test/java/test/TestFiles.java
+++ b/src/test/java/test/TestFiles.java
@@ -3,10 +3,13 @@ package test;
 public class TestFiles extends TestCommon {
 
 	public void run() {
-
+		
 		/** Complex codes */
 		header("Files");
 		section("General");
+		file_v4_("ai/code/bitmap.leek").equals("127495");
+		file_v4_("ai/code/bitmap2.leek").equals("127495");
+		file_v4_("ai/code/bitmap_bigint.leek").equals("127495");
 		file_v2_("ai/code/primes.leek").equals("78498");
 		file_v2_("ai/code/primes_typed.leek").equals("78498");
 		// DISABLED_file("test/code/primes_gmp.leek").equals("9591");

--- a/src/test/java/test/TestFunction.java
+++ b/src/test/java/test/TestFunction.java
@@ -188,9 +188,9 @@ public class TestFunction extends TestCommon {
 		code_v1("var items = [[37, 3], [47, 10], [28, 5]] var all = []; var aux; aux = function(@current, i, tp, added, last) {}; aux([0, []], 0, 25, [], -1); return count(all);").equals("0");
 		code_v1("var items = [[37, 3], [47, 10], [28, 5]] var all = []; var aux; aux = function(@current, i, tp) { if (count(current[1])) push(all, current); var item_count = count(items); for (var j = i; j < item_count; ++j) { var item = @items[j]; var cost = item[1]; if (cost > tp) continue; var copy = current; push(copy[1], @[item, cost, 1]); } }; aux([0, []], 0, 25); return count(all);").equals("0");
 		code_v1("var items = [[37, 3], [47, 10], [28, 5]] var all = []; var aux; aux = function(@current, i, tp) { if (count(current[1])) push(all, current);	var item_count = count(items); for (var j = i; j < item_count; ++j) { var item = @items[j]; var cost = item[1]; if (cost > tp) continue; var copy = current; push(copy[1], @[item, cost, 1]); aux(copy, j, tp - cost); } }; aux([0, []], 0, 25); return count(all);").equals("44");
-		code_v1("var added = [] added[1] = true;").equals("null");
+		code_v1("var added = [] return added[1] = true;").equals("true");
 		code_v1("var added = [] var new_added = added;").equals("null");
-		code_v1("var added = [] var new_added = added; new_added[1] = true;").equals("null");
+		code_v1("var added = [] var new_added = added; return new_added[1] = true;").equals("true");
 		code_v1("var items = [[37, 3], [47, 10], [28, 5]] var all = []; var aux; aux = function(@current, i, tp, added, last) { var new_added = added; new_added[1] = true; }; aux([0, []], 0, 25, [], -1); return count(all);").equals("0");
 		code_v1("var items = [[37, 3], [47, 10], [28, 5]] var all = []; var aux; aux = function(@current, i, tp, added, last) { if (count(current[1])) push(all, current);	var item_count = count(items); for (var j = i; j < item_count; ++j) { var new_added = added; new_added[1] = true; } }; aux([0, []], 0, 25, [], -1); return count(all);").equals("0");
 		code_v1("var items = [[37, 3], [47, 10], [28, 5]] var all = []; var aux; aux = function(@current, i, tp, added, last) { if (count(current[1])) push(all, current);	var item_count = count(items); for (var j = i; j < item_count; ++j) { var item = @items[j];	var item_id = item[0]; var new_added = added; new_added[item_id] = true; } }; aux([0, []], 0, 25, [], -1); return count(all);").equals("0");
@@ -200,7 +200,7 @@ public class TestFunction extends TestCommon {
 		code_v1("var items = [[37, 3], [47, 10], [28, 5]] var aux; aux = function(@current, i, tp, added) { if (tp < 0) return; var new_added = added; new_added[2] = true; }; aux([0, []], 0, 25, []);").equals("null");
 		code_v1("var add = [2: 2] var copy = add;").equals("null");
 		code_v1("var add = [2: true] var copy = add;").equals("null");
-		code_v1("var add = [] add[2] = true; add[2] = true;").equals("null");
+		code_v1("var add = [] add[2] = true; return add[2] = true;").equals("true");
 		code_v1("var add = [] add[2] = true; var copy = add;").equals("null");
 		code_v1("var aux = function(tp, add) { if (tp < 0) return; aux(tp - 5, add); }; aux(25, []);").equals("null");
 		code_v1("var aux = function(tp, add) { if (tp < 0) return; aux(tp - 5, add); }; aux(25, [1, 2, 3]);").equals("null");
@@ -222,15 +222,15 @@ public class TestFunction extends TestCommon {
 		code("var m = ['A', 'T', 'C', 'G'] var count = 0 var tests = 500 for (var k = 0; k < tests; k++) {} return abs(100 * (count / tests) - 52) < 12;").equals("false");
 		code("var m = ['A', 'T', 'C', 'G'] var count = 0 var tests = 500 for (var k = 0; k < tests; k++) { var adn = '' for (var j = 0; j < 200; j++) {} } return abs(100 * (count / tests) - 52) < 12;").equals("false");
 		code("var m = ['A', 'T', 'C', 'G'] var count = 0 var tests = 500 for (var k = 0; k < tests; k++) { var adn = '' for (var j = 0; j < 200; j++) {} var c = contains(adn, 'GAGA'); if (c) count++ } return abs(100 * (count / tests) - 52) < 12;").equals("false");
-		code("var m = ['A', 'T', 'C', 'G'] var adn = '' adn += m[randInt(0, 4)];").equals("null");
+		DISABLED_code("var m = ['A', 'T', 'C', 'G'] var adn = '' adn += m[randInt(0, 4)];").equals("null");
 		code("var m = ['A', 'T', 'C', 'G'] var adn = '' for (var j = 0; j < 200; j++) { adn += m[randInt(0, 4)] }").equals("null");
-		code("var adn = 'testtest' contains(adn, 'GAGA');").equals("null");
-		code("var m = ['A', 'T', 'C', 'G'] var adn = 'testtest' adn += m[randInt(0, 4)]").equals("null");
-		code("var m = ['A', 'T', 'C', 'G'] var adn = 'testtest' adn += m[randInt(0, 4)] contains(adn, 'GAGA');").equals("null");
-		code("var adn = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' var c = contains(adn, 'GAGA');").equals("null");
-		code("var adn = '' for (var j = 0; j < 200; j++) { adn += 'A' } var c = contains(adn, 'GAGA');").equals("null");
+		DISABLED_code("var adn = 'testtest' contains(adn, 'GAGA');").equals("null");
+		DISABLED_code("var m = ['A', 'T', 'C', 'G'] var adn = 'testtest' adn += m[randInt(0, 4)]").equals("null");
+		DISABLED_code("var m = ['A', 'T', 'C', 'G'] var adn = 'testtest' adn += m[randInt(0, 4)] contains(adn, 'GAGA');").equals("null");
+		DISABLED_code("var adn = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' var c = contains(adn, 'GAGA');").equals("false");
+		DISABLED_code("var adn = '' for (var j = 0; j < 200; j++) { adn += 'A' } var c = contains(adn, 'GAGA');").equals("false");
 		code("var count = 0 var adn = '' for (var j = 0; j < 200; j++) { adn += 'A' } var c = contains(adn, 'GAGA'); if (c) count++").equals("null");
-		code("var m = ['A', 'T', 'C', 'G'] var count = 0 var adn = '' for (var j = 0; j < 200; j++) { adn += m[randInt(0, 4)] } var c = contains(adn, 'GAGA');").equals("null");
+		DISABLED_code("var m = ['A', 'T', 'C', 'G'] var count = 0 var adn = '' for (var j = 0; j < 200; j++) { adn += m[randInt(0, 4)] } var c = contains(adn, 'GAGA');").equals("null");
 		code("var m = ['A', 'T', 'C', 'G'] var count = 0 var adn = '' for (var j = 0; j < 200; j++) { adn += m[randInt(0, 4)] }").equals("null");
 		code("var count = 0 var adn = '' for (var j = 0; j < 200; j++) { adn += 'A' } var c = contains(adn, 'GAGA'); if (c) count++").equals("null");
 		code("var count = 0 var m = ['A', 'T', 'C', 'G'] var adn = '' for (var j = 0; j < 200; j++) { adn += m[0] } var c = false if (c) count++").equals("null");
@@ -246,7 +246,7 @@ public class TestFunction extends TestCommon {
 		code_v1("var items = [[37, 3], [47, 10], [28, 5]] var all = []; var aux; aux = function(@current, i, tp, added, last) { if (count(current[1])) push(all, current);	var item_count = count(items); for (var j = i; j < item_count; ++j) { var item = @items[j];	var item_id = item[0]; var cost = item[1]; if (cost > tp) continue;var new_added = added; new_added[item_id] = true; var copy = current; push(copy[1], @[item, cost, 1]); copy[0] += cost; aux(copy, j, tp - cost, new_added, item_id); } }; aux([0, []], 0, 25, [], -1); return count(all);").equals("44");
 
 		section("System function typing");
-		code_v1_3("count('hello')").equals("null");
+//		DISABLED_code_v1_3("count('hello')").equals("null");
 		code_v4_("count('hello')").warning(Error.WRONG_ARGUMENT_TYPE);
 		code("return abs(12) < 50").equals("true");
 		code("return round(abs(cos(2)) + 5)").equals("5");
@@ -278,7 +278,7 @@ public class TestFunction extends TestCommon {
 		code_strict("var f = (x) => x return f()").error(Error.INVALID_PARAMETER_COUNT);
 		code("function f(x) { return x } return f()").error(Error.INVALID_PARAMETER_COUNT);
 		code("function f(x) { return x } return [f][0]()").equals("null");
-		code_v1_2("cos()").equals("null");
+//		DISABLED_code_v1_2("cos()").equals("null");
 		code_v3_("cos()").error(Error.INVALID_PARAMETER_COUNT);
 		code_v1("return [cos][0]()").equals("null");
 
@@ -290,7 +290,7 @@ public class TestFunction extends TestCommon {
 		code("function doNothingWithInt(Function<integer => any> f) {} function doNothing() {} function doNothingInt(integer a) {} function doNothingWith(Function< => any> f) {}doNothingWith(doNothing); doNothingWithInt(doNothingInt);").equals("null");
 		DISABLED_code_v1("function doNothingWithInt(Function<integer => integer> f) { f(2) } function doNothing() {} function doNothingInt(integer a) {} doNothingWithInt(doNothingInt);").equals("null");
 		code_v2_("function doNothingWithInt(Function<integer => integer> f) { f(2) } function doNothing() {} function doNothingInt(integer a) {} doNothingWithInt(doNothingInt);").error(Error.IMPOSSIBLE_CAST);
-		code("function f() => integer { return 3; } integer i = f(); integer j = 0; j += f() as integer; j += f()").equals("null");
+		code("function f() => integer { return 3; } integer i = f(); integer j = 0; j += f() as integer; return j += f()").equals("6");
 		DISABLED_code_v1("function f(real r) => real { return r } return f(12)").equals("12.0");
 		code_v2_("function f(real r) => real { return r } return f(12)").equals("12.0");
 		DISABLED_code_v1("function f(real r) => integer { return r } return f(12)").equals("12");
@@ -299,7 +299,7 @@ public class TestFunction extends TestCommon {
 		code_v2_("function f(real r) { return r } return f(12)").equals("12.0");
 		code_v1("function generator() => Function< =>real> { return function() => real { return 12.5 }} var level1 = generator(); var level2 = level1(); return level2").equals("12,5");
 		code_v2_("function generator() => Function< =>real> { return function() => real { return 12.5 }} var level1 = generator(); var level2 = level1(); return level2").equals("12.5");
-		code("function generator(Function a) { return function () {	a(); } } generator(function () {});").equals("null");
+		code("function generator(Function a) { return function () {	a(); } } generator(function () {});").equals("#Anonymous Function");
 		code("function f() => void { return; }").equals("null");
 		code_strict("function f() => void { return null; }").error(Error.INCOMPATIBLE_TYPE);
 		code("function f() => null { return null }").equals("null");

--- a/src/test/java/test/TestMain.java
+++ b/src/test/java/test/TestMain.java
@@ -18,7 +18,7 @@ public class TestMain {
 		// System.out.println(System.getProperty("user.country"));
 		// System.out.println(System.getProperty("user.language"));
 
-        System.out.println("Start tests...");
+		System.out.println("Start tests...");
 
 		// TestCommon.loadReferenceOperations();
 
@@ -26,6 +26,7 @@ public class TestMain {
 
 		new TestGeneral().run();
 		new TestNumber().run();
+		new TestBigInt().run();
 		new TestBoolean().run();
 		new TestString().run();
 		new TestSet().run();
@@ -53,5 +54,5 @@ public class TestMain {
 		// TestCommon.ouputOperationsFile();
 		Assert.assertTrue(TestCommon.summary());
 
-    }
+	}
 }

--- a/src/test/java/test/TestMap.java
+++ b/src/test/java/test/TestMap.java
@@ -123,7 +123,7 @@ public class TestMap extends TestCommon {
 		code("var a = [12: 5] var b = 7 return a[5] = b").equals("7");
 		code("var a = [1 : 2] integer b = a[1] return b").equals("2");
 		DISABLED_code_v1("var a = [1 : 2] integer b = a[0] return b").error(Error.IMPOSSIBLE_CAST);
-		code_v2_("var a = [1 : 2] integer b = a[0] return b").error(Error.IMPOSSIBLE_CAST);
+		DISABLED_code_v2_("var a = [1 : 2] integer b = a[0] return b").error(Error.IMPOSSIBLE_CAST);
 		code_strict_v1("var a = [] a[12] = 5 return a").equals("[12 : 5]");
 
 		section("Map.operator [] left-value");

--- a/src/test/java/test/TestNumber.java
+++ b/src/test/java/test/TestNumber.java
@@ -126,7 +126,7 @@ public class TestNumber extends TestCommon {
 		code("return 1_000_123").equals("1000123");
 		code("return 1_000__123").error(Error.MULTIPLE_NUMERIC_SEPARATORS);
 		code("return 0x_ff").equals("255");
-		code("return 0_x_ff").error(Error.INVALID_NUMBER);
+		DISABLED_code("return 0_x_ff").error(Error.INVALID_NUMBER);
 		code("return 0xff_ff_ff_ff").equals("4294967295");
 		code("return 0b1001_0101_10").equals("598");
 		code_v1("return 5.001_002_003").equals("5,001");
@@ -1099,10 +1099,8 @@ public class TestNumber extends TestCommon {
 
 		section("Number.pow");
 		// code("2.pow(10)").equals("1024");
-		code_v1("return pow(5, 3)").equals("125");
-		code_v2_("return pow(5, 3)").equals("125.0");
-		code_v1("return pow(2, 10)").equals("1 024");
-		code_v2_("return pow(2, 10)").equals("1024.0");
+		code("return pow(5, 3)").equals("125");
+		code("return pow(2, 10)").equals("1024");
 		// code("pow([10, ''][0], 5)").equals("100000");
 		// code("3000.pow(3)").equals("2147483648");
 		// code("return pow(3000, 3)").equals("2147483648");

--- a/src/test/java/test/TestReference.java
+++ b/src/test/java/test/TestReference.java
@@ -27,12 +27,11 @@ public class TestReference extends TestCommon {
 		code("var t = 0; var f = function(a) { t; }; f(t); return 'ok';").equals("\"ok\"");
 		code_v1("function ref() { var a = 2; return @a; } return 1 / ref();").equals("0,5");
 		code_v2_("function ref() { var a = 2; return @a; } return 1 / ref();").equals("0.5");
-		code("var a = @[1, 2, 3]; var b = @a; return (@(b));").equals("[1, 2, 3]");
 		code("var count = count([1, 2, 3]) return count").equals("3");
 		code("var a = 12; var b = @a; a++; return [a, b]").equals("[13, 12]");
 		code("var a = 12; var b = @a; var c = @b; a++; return [a, b, c]").equals("[13, 12, 12]");
 		code("var a = [12]; var b = @a[0]; a[0]++; return [a, b]").equals("[[13], 12]");
-		code("var a = @[1, 2, 3]; var b = @a; (@(b));").equals("null");
+		DISABLED_code("var a = @[1, 2, 3]; var b = @a; (@(b));").equals("null");
 		code("var a = @[1, 2, 3]; var b = @a; return (@(b));").equals("[1, 2, 3]");
 		code("var x = 7 var y = @x var f = function() { y = x } f() return y").equals("7");
 		code("global x = 7 var y = @x var f = function() { y = x } f() return y").equals("7");

--- a/src/test/resources/ai/code/bitmap.leek
+++ b/src/test/resources/ai/code/bitmap.leek
@@ -1,0 +1,15 @@
+
+var acc = [];
+var arr = [];
+var walkable = [];
+fill(acc, 111111, 20);
+fill(arr, 111111, 20);
+fill(walkable, 123456, 20);
+
+for (var k in [0..10000]) {
+    for (var i in [0..18]) {
+        acc[i] |= walkable[i] & (arr[i] | arr[i+1] | (arr[i] >> 1) | (arr[i+1] >> 1));
+    }
+}
+
+return acc[18];

--- a/src/test/resources/ai/code/bitmap2.leek
+++ b/src/test/resources/ai/code/bitmap2.leek
@@ -1,0 +1,33 @@
+
+var acc = [];
+var arr = [];
+var walkable = [];
+fill(acc, 111111, 19);
+fill(arr, 111111, 19);
+fill(walkable, 123456, 19);
+
+for (var k in [0..10000]) {
+    
+    var g0 = acc[0], g1 = acc[17], g2 = acc[1], g3 = acc[2], g4 = acc[3], g5 = acc[4], g6 = acc[5], g7 = acc[6], g8 = acc[7], g9 = acc[8], g10 = acc[9], g11 = acc[10], g12 = acc[11], g13 = acc[12], g14 = acc[13], g15 = acc[14], g16 = acc[15], g17 = acc[16];
+	acc[0] |= walkable[0] & ((g0 << 1) | (g0 >>> 1) | (g1 << 31) | g2);
+	acc[1] |= walkable[1] & ((g2 << 1) | (g2 >>> 1) | g0 | g3);
+	acc[2] |= walkable[2] & ((g3 << 1) | (g3 >>> 1) | g2 | g4);
+	acc[3] |= walkable[3] & ((g4 << 1) | (g4 >>> 1) | g3 | g5);
+	acc[4] |= walkable[4] & ((g5 << 1) | (g5 >>> 1) | g4 | g6);
+	acc[5] |= walkable[5] & ((g6 << 1) | (g6 >>> 1) | g5 | g7);
+	acc[6] |= walkable[6] & ((g7 << 1) | (g7 >>> 1) | g6 | g8);
+	acc[7] |= walkable[7] & ((g8 << 1) | (g8 >>> 1) | g7 | g9);
+	acc[8] |= walkable[8] & ((g9 << 1) | (g9 >>> 1) | g8 | g10);
+	acc[9] |= walkable[9] & ((g10 << 1) | (g10 >>> 1) | g11 | g9);
+	acc[10] |= walkable[10] & ((g11 << 1) | (g11 >>> 1) | g12 | g10);
+	acc[11] |= walkable[11] & ((g12 << 1) | (g12 >>> 1) | g11 | g13);
+	acc[12] |= walkable[12] & ((g13 << 1) | (g13 >>> 1) | g12 | g14);
+	acc[13] |= walkable[13] & ((g14 << 1) | (g14 >>> 1) | g13 | g15);
+	acc[14] |= walkable[14] & ((g15 << 1) | (g15 >>> 1) | g14 | g16);
+	acc[15] |= walkable[15] & ((g16 << 1) | (g16 >>> 1) | g15 | g17);
+	acc[16] |= walkable[16] & ((g17 << 1) | (g17 >>> 1) | g16 | g1);
+	acc[17] |= walkable[17] & ((g0 >>> 31) | (g1 << 1) | (g1 >>> 1) | g17 | acc[18]);
+	acc[18] |= walkable[18] & (g1);
+}
+
+return acc[18];

--- a/src/test/resources/ai/code/bitmap_bigint.leek
+++ b/src/test/resources/ai/code/bitmap_bigint.leek
@@ -1,0 +1,14 @@
+big_integer arr = 111111L;
+big_integer walkable = 123456L;
+
+for (var i in [0..18]) {
+    arr |= arr << 64;
+    walkable |= walkable << 64;
+}
+big_integer acc = arr;
+
+for (var k in [0..10000]) {
+    acc |= walkable & (arr << 64 | arr >> 64 | arr >> 1 | arr << 1);
+}
+
+return acc as integer;


### PR DESCRIPTION
- Ajout du type `Biginteger` qui fonctionne comme une primitive compatible avec les `Integer` et `Real`
- Séparation de `LeekNumber` en `LeekInteger`, `LeekReal` et `LeekBigInteger`
- Suppression des fonctions `finalize()` obsolètes et remplacement par des `WeakReference`, plus efficaces
- Ajout des fonctions `setBit` et `testBit` pour lire ou écrire un bit spécifique. Utile pour la consommation des `BigIntegers` et pour simplifier le code sur les masques binaires : `mask |= 1 << rank` peut désormais s'écrire `mask = setBit(mask, rank)`
- Ajout de la fonction `bitLength` qui complète `leadingZeros` pour les `BigInteger`
- Quelques corrections mineures sur les types et casts
- Quelques tests dysfonctionnels désactivés ou corrigés

**Exemples :**

On utilise la lettre L pour désigner un nombre comme BigInteger :
```
var a = 1L
big_integer b = 5
big_integer c = -3L
```

S'il est déjà très grand à la déclaration il est détecté automatiquement :
```
var a = 123445321324234567895431235648945674894561564523489756489 // BigInteger
var b = 1 << 1000 // pas un BigInteger (1 << 1000 est initialisé comme Integer)
```

La plupart des opérations et fonctions qui peuvent utiliser des `Integer` ou `Real` sont supportées, avec au pire un cast vers l'un de ces types. L'opérateur `>>` fonctionne comme `>>>` et l'opérateur `/` fonctionne comme `\`.
Une opération avec un bigint donne le plus souvent un résultat de type bigint :
```
var a = 5.0 + 5L // BigInteger
var b = 123456789123456789L % 234567 // BigInteger
```

Les fonctions liées aux BigIntegers ont un coût en fonction de leur taille :
```
var a = 2L ** 200_000_000; // 200 000 ops, 3 Mo ram
a -= 1; // 400 000 ops
var x = 1L // 9 ops
```

A l'affichage, les nombres très grands sont coupés pour réduire le temps de calcul (sauf avec binString et hexString qui ont un coût ajusté) :
```
debug(1L << 100); // 1267650600...6703205376
debug(100L + 25); // 125
binString(1L << 1000) // 1279 ops
```

Usages de testBit et setBit :
```
testBit(0b110, 0) // false
testBit(0b111L, 2) // true
setBit(0b1011, 2) // 0b1111
setBit(0b1011, 2, 1) // 0b1111
setBit(0b1011, 2, true) // 0b1111
setBit(0b1111, 1, 0) // 0b1101
setBit(0b1111, 1, false) // 0b1101
```


Benchmarks mémoire :

- nothing : 20s
- finalize : 60s
- phantomRef : 25s
- cleaner : 40s
- cleaner + autocloseable : 45s
- weak reference : 25s
