### PR TITLE
Fix intervalContains causing Java compilation errors

### DIFF
--- a/src/main/java/leekscript/runner/LeekFunctions.java
+++ b/src/main/java/leekscript/runner/LeekFunctions.java
@@ -274,6 +274,7 @@ public class LeekFunctions {
 		method("intervalContains", "Interval", 2, new CallableVersion[] {
 			new CallableVersion(Type.BOOL, new Type[] { Type.INTERVAL, Type.INT }),
 			new CallableVersion(Type.BOOL, new Type[] { Type.INTERVAL, Type.REAL }),
+			new CallableVersion(Type.BOOL, new Type[] { Type.INTERVAL, Type.INT_OR_REAL }),
 		});
 		method("intervalAverage", "Interval", 3, Type.REAL, new Type[] { Type.INTERVAL });
 		method("intervalIntersection", "Interval", 3, new CallableVersion[] {

--- a/src/main/java/leekscript/runner/LeekFunctions.java
+++ b/src/main/java/leekscript/runner/LeekFunctions.java
@@ -271,7 +271,10 @@ public class LeekFunctions {
 		method("intervalIsClosed", "Interval", 1, Type.BOOL, new Type[] { Type.INTERVAL });
 		method("intervalIsRightClosed", "Interval", 1, Type.BOOL, new Type[] { Type.INTERVAL });
 		method("intervalIsLeftClosed", "Interval", 1, Type.BOOL, new Type[] { Type.INTERVAL });
-		method("intervalContains", "Interval", 2, Type.BOOL, new Type[] { Type.INTERVAL, Type.INT_OR_REAL });
+		method("intervalContains", "Interval", 2, new CallableVersion[] {
+			new CallableVersion(Type.BOOL, new Type[] { Type.INTERVAL, Type.INT }),
+			new CallableVersion(Type.BOOL, new Type[] { Type.INTERVAL, Type.REAL }),
+		});
 		method("intervalAverage", "Interval", 3, Type.REAL, new Type[] { Type.INTERVAL });
 		method("intervalIntersection", "Interval", 3, new CallableVersion[] {
 			new CallableVersion(Type.REAL_INTERVAL, new Type[] { Type.REAL_INTERVAL, Type.REAL_INTERVAL }),

--- a/src/main/java/leekscript/runner/values/IntervalLeekValue.java
+++ b/src/main/java/leekscript/runner/values/IntervalLeekValue.java
@@ -28,6 +28,13 @@ public abstract class IntervalLeekValue implements LeekValue {
 
 	public abstract boolean intervalContains(AI ai, double x) throws LeekRunException;
 
+	public boolean intervalContains(AI ai, Object value) throws LeekRunException {
+		if (value instanceof Long l) {
+			return intervalContains(ai, (long) l);
+		}
+		return intervalContains(ai, ai.real(value));
+	}
+
 	public abstract double intervalAverage(AI ai) throws LeekRunException;
 
 	public abstract boolean intervalIsBounded(AI ai);

--- a/src/main/java/leekscript/runner/values/IntervalLeekValue.java
+++ b/src/main/java/leekscript/runner/values/IntervalLeekValue.java
@@ -28,11 +28,11 @@ public abstract class IntervalLeekValue implements LeekValue {
 
 	public abstract boolean intervalContains(AI ai, double x) throws LeekRunException;
 
-	public boolean intervalContains(AI ai, Object value) throws LeekRunException {
+	public boolean intervalContains(AI ai, Number value) throws LeekRunException {
 		if (value instanceof Long l) {
 			return intervalContains(ai, (long) l);
 		}
-		return intervalContains(ai, ai.real(value));
+		return intervalContains(ai, value.doubleValue());
 	}
 
 	public abstract double intervalAverage(AI ai) throws LeekRunException;

--- a/src/test/java/test/TestInterval.java
+++ b/src/test/java/test/TestInterval.java
@@ -113,6 +113,20 @@ public class TestInterval extends TestCommon {
 		code("return Infinity in [0..[").equals("true");
 		code_v3_("return Integer.MAX_VALUE in [0.0 ..[").equals("true");
 
+		section("Interval.intervalContains");
+		code("return intervalContains([1..2], 1)").equals("true");
+		code("return intervalContains([1..2], 2)").equals("true");
+		code("return intervalContains([1..2], 3)").equals("false");
+		code("return intervalContains([1..2], 0)").equals("false");
+		code("return intervalContains([1..2], 1.5)").equals("true");
+		code("return intervalContains([1..1], 1)").equals("true");
+		code("return intervalContains([2..1], 1)").equals("false");
+		code("return intervalContains([1..2[, 2)").equals("false");
+		code("return intervalContains(]1..2[, 1)").equals("false");
+		code("return intervalContains([1.0..2.0], 1.5)").equals("true");
+		code("return intervalContains([1.0..2.0[, 2.0)").equals("false");
+		code("var x = 2 return intervalContains([1..3], x)").equals("true");
+
 		section("Interval typing");
 		code_strict_v4_("Interval i = [0..[ return i instanceof Interval").equals("true");
 		code_v2_("return [0..1].class").equals("<class Interval>");

--- a/src/test/java/test/TestInterval.java
+++ b/src/test/java/test/TestInterval.java
@@ -126,6 +126,9 @@ public class TestInterval extends TestCommon {
 		code("return intervalContains([1.0..2.0], 1.5)").equals("true");
 		code("return intervalContains([1.0..2.0[, 2.0)").equals("false");
 		code("var x = 2 return intervalContains([1..3], x)").equals("true");
+		code("function f(x) { return intervalContains([1..3], x) } return f(2)").equals("true");
+		code("function f(x) { return intervalContains([1..3], x) } return f(1.5)").equals("true");
+		code("function f(x) { return intervalContains([1..3], x) } return f(5)").equals("false");
 
 		section("Interval typing");
 		code_strict_v4_("Interval i = [0..[ return i instanceof Interval").equals("true");


### PR DESCRIPTION
The intervalContains function was registered with Type.INT_OR_REAL as its
second parameter type. When the compiler generated a generic wrapper function
(due to type mismatches triggering the "unsafe" code path), INT_OR_REAL mapped
to Java type Number. However, IntervalLeekValue.intervalContains only had
overloads for (AI, long) and (AI, double), not (AI, Number), causing a Java
compilation error at runtime.

Fix: Split the registration into separate INT and REAL versions so the generic
wrapper generates correct primitive-typed conversions. Also add an Object
overload to IntervalLeekValue as a safety net for unknown argument types.

https://claude.ai/code/session_01Ud6bPswWzgrPCE3dpkABjR