### PR TITLE
Fix l'égalité des fonctions utilisateur

### DIFF
--- a/src/main/java/leekscript/compiler/JavaWriter.java
+++ b/src/main/java/leekscript/compiler/JavaWriter.java
@@ -4,13 +4,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.TreeMap;
-import java.util.function.Function;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import leekscript.util.Json;
 
 import leekscript.compiler.bloc.AbstractLeekBlock;
+import leekscript.compiler.bloc.FunctionBlock;
 import leekscript.common.CompoundType;
 import leekscript.common.FunctionType;
 import leekscript.common.Type;
@@ -33,6 +32,7 @@ public class JavaWriter {
 	public AbstractLeekBlock currentBlock = null;
 	public HashMap<String, ArrayList<CallableVersion>> genericFunctions = new HashMap<>();
 	public HashSet<LeekFunctions> anonymousSystemFunctions = new HashSet<>();
+	public HashSet<FunctionBlock> anonymousUserFunctions = new HashSet<>();
 	private boolean operationsEnabled = true;
 	public boolean lastInstruction = false;
 	public Options options;
@@ -330,6 +330,10 @@ public class JavaWriter {
 		return key;
 	}
 
+	public void generateAnonymousUserFunction(FunctionBlock function) {
+		anonymousUserFunctions.add(function);
+	}
+
 	public void generateAnonymousSystemFunction(LeekFunctions system_function) {
 		anonymousSystemFunctions.add(system_function);
 		for (var version : system_function.getVersions()) {
@@ -452,6 +456,15 @@ public class JavaWriter {
 			}
 			addLine(");");
 			addLine("}};");
+			addLine();
+		}
+	}
+
+	public void writeAnonymousUserFunctions(MainLeekBlock block) {
+		for (var function : anonymousUserFunctions) {
+			addCode("private FunctionLeekValue ufunction_" + function.getName() + " = ");
+			function.compileAnonymousFunction(block, this);
+			addLine(";");
 			addLine();
 		}
 	}

--- a/src/main/java/leekscript/compiler/bloc/MainLeekBlock.java
+++ b/src/main/java/leekscript/compiler/bloc/MainLeekBlock.java
@@ -364,6 +364,7 @@ public class MainLeekBlock extends AbstractLeekBlock {
 
 		writer.writeGenericFunctions(this);
 		writer.writeAnonymousSystemFunctions(this);
+		writer.writeAnonymousUserFunctions(this);
 
 		writer.addLine("}");
 	}

--- a/src/main/java/leekscript/compiler/expression/LeekVariable.java
+++ b/src/main/java/leekscript/compiler/expression/LeekVariable.java
@@ -264,7 +264,8 @@ public class LeekVariable extends Expression {
 			writer.addCode("rfunction_" + token.getWord() + ".get()");
 		} else if (type == VariableType.FUNCTION) {
 			FunctionBlock user_function = mainblock.getUserFunction(token.getWord());
-			user_function.compileAnonymousFunction(mainblock, writer);
+			writer.generateAnonymousUserFunction(user_function);
+			writer.addCode("ufunction_" + token.getWord());
 		} else if (type == VariableType.SYSTEM_CONSTANT) {
 			var constant = LeekConstants.get(token.getWord());
 			if (constant.getType() == Type.INT) writer.addCode(String.valueOf(constant.getIntValue()) + "l");
@@ -281,7 +282,8 @@ public class LeekVariable extends Expression {
 		} else if (type == VariableType.SYSTEM_FUNCTION) {
 			FunctionBlock user_function = mainblock.getUserFunction(token.getWord());
 			if (user_function != null) {
-				user_function.compileAnonymousFunction(mainblock, writer);
+				writer.generateAnonymousUserFunction(user_function);
+				writer.addCode("ufunction_" + token.getWord());
 			} else {
 				var system_function = LeekFunctions.getValue(token.getWord(), writer.getOptions().useExtra());
 				writer.generateAnonymousSystemFunction(system_function);
@@ -333,7 +335,8 @@ public class LeekVariable extends Expression {
 		} else if (type == VariableType.SYSTEM_FUNCTION) {
 			FunctionBlock user_function = mainblock.getUserFunction(token.getWord());
 			if (user_function != null) {
-				user_function.compileAnonymousFunction(mainblock, writer);
+				writer.generateAnonymousUserFunction(user_function);
+				writer.addCode("ufunction_" + token.getWord());
 			} else {
 				var system_function = LeekFunctions.getValue(token.getWord(), writer.getOptions().useExtra());
 				writer.generateAnonymousSystemFunction(system_function);
@@ -356,7 +359,8 @@ public class LeekVariable extends Expression {
 			else writer.addCode("null");
 		} else if (type == VariableType.FUNCTION) {
 			FunctionBlock user_function = mainblock.getUserFunction(token.getWord());
-			user_function.compileAnonymousFunction(mainblock, writer);
+			writer.generateAnonymousUserFunction(user_function);
+			writer.addCode("ufunction_" + token.getWord());
 		} else if (type == VariableType.CLASS) {
 			if (classDeclaration.internal) {
 				writer.addCode(token.getWord().toLowerCase() + "Class");

--- a/src/test/java/test/TestOperators.java
+++ b/src/test/java/test/TestOperators.java
@@ -127,6 +127,8 @@ public class TestOperators extends TestCommon {
 		code("return function() {} == function() {}").equals("false");
 		code("return endsWith == function() {}").equals("false");
 		code("return endsWith == endsWith").equals("true");
+		code("function test() {} return test == test").equals("true");
+		code("function a() {} function b() {} return a == b").equals("false");
 
 		String[] values1 = new String[] { "false", "true", "0", "1", "12", "''", "'0'", "'1'", "'12'", "'lama'", "'true'", "'false'",
 			"[]", "[0]", "[1]", "[12]", "[1,2,3]", "null" };


### PR DESCRIPTION
## Summary
- Corrige le bug où `test == test` retournait `false` pour les fonctions utilisateur (#2625)
- Chaque référence à une fonction utilisateur créait une nouvelle instance de `FunctionLeekValue`, rendant la comparaison par identité Java toujours `false`
- Les fonctions utilisateur sont maintenant cachées dans des champs (`ufunction_*`), comme les fonctions système (`endsWith == endsWith` marchait déjà), garantissant une seule instance par fonction

## Test plan
- [x] Tests ajoutés : `function test() {} return test == test` → `true`
- [x] Tests ajoutés : `function a() {} function b() {} return a == b` → `false`
- [x] 14575 / 14575 tests passent, 0 erreurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)