### PR TITLE
feat(compiler): syntaxe d'accès indexé optionnel `a?[b]`

### DIFF
--- a/src/main/java/leekscript/compiler/WordCompiler.java
+++ b/src/main/java/leekscript/compiler/WordCompiler.java
@@ -98,6 +98,14 @@ public class WordCompiler {
 		if (isInterrupted()) throw new LeekCompilerException(mTokens.get(), Error.AI_TIMEOUT);
 	}
 
+	// Vrai si `b` suit immédiatement `a` dans le source (aucun espace entre les deux),
+	// utilisé pour distinguer `a?[i]` (accès optionnel) de `a ? [i] : [j]` (ternaire).
+	private static boolean adjacent(Token a, Token b) {
+		var la = a.getLocation();
+		var lb = b.getLocation();
+		return la.getEndLine() == lb.getStartLine() && lb.getStartColumn() == la.getEndColumn() + 1;
+	}
+
 	public void readCode() throws LeekCompilerException {
 
 		firstPass();
@@ -1718,6 +1726,18 @@ public class WordCompiler {
 			if (retour.needOperator()) {
 				// Si on attend un opérateur mais qu'il vient pas
 
+				// Accès indexé optionnel `a?[b]` : court-circuite à null si `a` est null.
+				// Le `?` doit être collé au `[` pour lever l'ambiguïté avec le ternaire
+				// `cond ? [1, 2] : [3, 4]` (dont les branches sont des littéraux tableau).
+				boolean optionalBracket = false;
+				if (word.getType() == TokenType.OPERATOR && word.getWord().equals("?")
+						&& mTokens.get(1).getType() == TokenType.BRACKET_LEFT && !inInterval
+						&& adjacent(word, mTokens.get(1))) {
+					mTokens.skip(); // ?
+					word = mTokens.get(); // [
+					optionalBracket = true;
+				}
+
 				if (word.getType() == TokenType.BRACKET_LEFT && !inInterval) {
 
 					var save = mTokens.getPosition();
@@ -1777,7 +1797,7 @@ public class WordCompiler {
 							throw new LeekCompilerException(mTokens.get(), Error.CLOSING_SQUARE_BRACKET_EXPECTED);
 						}
 					}
-					retour.addBracket(bracket, start, colon, end, colon2, stride, mTokens.get());
+					retour.addBracket(bracket, start, colon, end, colon2, stride, mTokens.get(), optionalBracket);
 
 				} else if (word.getType() == TokenType.PAR_LEFT) {
 

--- a/src/main/java/leekscript/compiler/expression/LeekArrayAccess.java
+++ b/src/main/java/leekscript/compiler/expression/LeekArrayAccess.java
@@ -27,9 +27,18 @@ public class LeekArrayAccess extends Expression {
 	private Token colon2;
 	private Expression stride;
 	private Type type;
+	private boolean optional = false; // accès indexé optionnel `a?[b]`
 
 	public LeekArrayAccess(Token openingBracket) {
 		openingBracket.setExpression(this);
+	}
+
+	public void setOptional(boolean optional) {
+		this.optional = optional;
+	}
+
+	public boolean isOptional() {
+		return optional;
 	}
 
 	public void setTabular(Expression tabular) {
@@ -186,6 +195,14 @@ public class LeekArrayAccess extends Expression {
 		} else {
 			var key = mCase instanceof LeekString ls ? ls.getText() : null;
 			this.type = mTabular.getType().elementAccess(compiler.getMainBlock().getVersion(), compiler.getMainBlock().isStrict(), key);
+		}
+
+		// Accès indexé optionnel `a?[b]` : identique à `a[b]` au runtime (l'indexation
+		// renvoie déjà null pour un conteneur null ou un index hors bornes), mais le
+		// résultat est explicitement typé `element | null`. Utile surtout en mode
+		// strict, où `a[b]` est sinon typé non-null. Résultat nullable ⇒ pas une lvalue.
+		if (optional) {
+			this.type = Type.compound(this.type, Type.NULL);
 		}
 	}
 
@@ -662,7 +679,8 @@ public class LeekArrayAccess extends Expression {
 
 	@Override
 	public boolean isLeftValue() {
-		return true;
+		// Un accès optionnel `a?[b]` n'est pas assignable (résultat nullable)
+		return !optional;
 	}
 
 	@Override

--- a/src/main/java/leekscript/compiler/expression/LeekExpression.java
+++ b/src/main/java/leekscript/compiler/expression/LeekExpression.java
@@ -197,7 +197,7 @@ public class LeekExpression extends Expression {
 		mExpression2 = null;
 	}
 
-	private static LeekArrayAccess createArrayAccess(Token bracket, Expression tabular, Expression casevalue, Token colon, Expression endIndex, Token colon2, Expression stride, Token closingBracket) {
+	private static LeekArrayAccess createArrayAccess(Token bracket, Expression tabular, Expression casevalue, Token colon, Expression endIndex, Token colon2, Expression stride, Token closingBracket, boolean optional) {
 		var exp = new LeekArrayAccess(bracket);
 		exp.setTabular(tabular);
 		exp.setCase(casevalue);
@@ -206,25 +206,30 @@ public class LeekExpression extends Expression {
 		exp.setColon2(colon2);
 		exp.setStride(stride);
 		exp.setClosingBracket(closingBracket);
+		exp.setOptional(optional);
 		return exp;
 	}
 
 	public void addBracket(Token bracket, Expression casevalue, Token colon, Expression endIndex, Token colon2, Expression stride, Token closingBracket) {
+		addBracket(bracket, casevalue, colon, endIndex, colon2, stride, closingBracket, false);
+	}
+
+	public void addBracket(Token bracket, Expression casevalue, Token colon, Expression endIndex, Token colon2, Expression stride, Token closingBracket, boolean optional) {
 		// On doit ajouter ce crochet au dernier élément ajouté
 		if (mExpression1 != null && mExpression2 == null) {
 			if (mExpression1 instanceof LeekExpression le1 && !isTerminalOperator(le1.getOperator()))
-				le1.addBracket(bracket, casevalue, colon, endIndex, colon2, stride, closingBracket);
+				le1.addBracket(bracket, casevalue, colon, endIndex, colon2, stride, closingBracket, optional);
 			else {
-				mExpression1 = createArrayAccess(bracket, mExpression1, casevalue, colon, endIndex, colon2, stride, closingBracket);
+				mExpression1 = createArrayAccess(bracket, mExpression1, casevalue, colon, endIndex, colon2, stride, closingBracket, optional);
 			}
 		}
 		else if (mExpression2 != null) {
 			if (mOperator == Operators.AS) {
-				wrapAndReset(createArrayAccess(bracket, cloneAsSubExpression(), casevalue, colon, endIndex, colon2, stride, closingBracket));
+				wrapAndReset(createArrayAccess(bracket, cloneAsSubExpression(), casevalue, colon, endIndex, colon2, stride, closingBracket, optional));
 			} else if (mExpression2 instanceof LeekExpression le2 && !isTerminalOperator(le2.getOperator()))
-				le2.addBracket(bracket, casevalue, colon, endIndex, colon2, stride, closingBracket);
+				le2.addBracket(bracket, casevalue, colon, endIndex, colon2, stride, closingBracket, optional);
 			else {
-				mExpression2 = createArrayAccess(bracket, mExpression2, casevalue, colon, endIndex, colon2, stride, closingBracket);
+				mExpression2 = createArrayAccess(bracket, mExpression2, casevalue, colon, endIndex, colon2, stride, closingBracket, optional);
 			}
 		}
 	}

--- a/src/test/java/test/TestArray.java
+++ b/src/test/java/test/TestArray.java
@@ -164,6 +164,53 @@ public class TestArray extends TestCommon {
 		code("var a = [1, 2, 3] integer b = a[0] return b").equals("1");
 	}
 
+	/**
+	 * Accès indexé optionnel `a?[b]` : au runtime identique à `a[b]` (l'indexation
+	 * renvoie déjà null pour un conteneur null ou un index hors bornes), mais le
+	 * résultat est typé `element | null`. Utile surtout en mode strict, où `a[b]`
+	 * est sinon typé non-null. Le `?` doit être collé au `[` pour ne pas être
+	 * confondu avec le ternaire `cond ? [..] : [..]`.
+	 */
+	@Test
+	public void testOptional_array_access() throws Exception {
+		section("Array.operator ?[]");
+		// Au runtime, `a?[b]` se comporte exactement comme `a[b]`
+		code_v4_("var a = [10, 20, 30] return a?[1]").equals("20");
+		code_v4_("var a = [10, 20, 30] return a?[0] + a?[2]").equals("40");
+		code_v4_("var a = null return a?[1]").equals("null");
+		// Map
+		code_v4_("var m = [\"x\": 5] return m?[\"x\"]").equals("5");
+		code_v4_("Map<string, integer>? m = null return m?[\"x\"]").equals("null");
+		// String
+		code_v4_("var s = \"abc\" return s?[1]").equals("\"b\"");
+		code_v4_("string? s = null return s?[1]").equals("null");
+		// Tranche
+		code_v4_("var a = [10, 20, 30] return a?[0:1]").equals("[10]");
+		// Objet / classe : indexation par nom de membre
+		code_v4_("class A { public x = 5 } var a = new A() return a?[\"x\"]").equals("5");
+		code_v4_("class A { public x = 5 } A? a = null return a?[\"x\"]").equals("null");
+		// Chaînage
+		code_v4_("var a = [[1, 2], [3, 4]] return a?[0]?[1]").equals("2");
+		code_v4_("var a = null return a?[0]?[1]").equals("null");
+		// Le ternaire avec branches tableau reste non ambigu (espace entre `?` et `[`)
+		code_v4_("var c = true return c ? [1, 2] : [3, 4]").equals("[1, 2]");
+		code_v4_("return 1 > 2 ? [1, 2] : [3, 4]").equals("[3, 4]");
+		// Accès optionnel non assignable
+		code_v4_("var a = [1] a?[0] = 5 return a").error(Error.CANT_ASSIGN_VALUE);
+
+		// Le `?` force le type `element | null`, visible en mode strict où `a[b]`
+		// est sinon typé non-null :
+		// `a[0]` y est non-null (assignable à integer sans broncher)...
+		code_strict_v4_("Array<integer> a = [1] integer x = a[0] return x").equals("1");
+		// ...alors que `a?[0]` est `integer | null` : assigner à un integer non-null
+		// est une conversion descendante (avertissement en strict)...
+		code_strict_v4_("Array<integer> a = [1] integer x = a?[0] return x").warning(Error.DANGEROUS_CONVERSION_VARIABLE);
+		// ...et s'assigne sans broncher à un type nullable.
+		code_strict_v4_("Array<integer> a = [1] integer? x = a?[0] return x").equals("1");
+		// Classe en mode strict : `obj?[member]` est nullable
+		code_strict_v4_("class A { public x = 5 } var a = new A() integer? x = a?[\"x\"] return x").equals("5");
+	}
+
 	@Test
 	public void testTyped_array_numeric_coercion() throws Exception {
 		section("Typed array numeric coercion");


### PR DESCRIPTION
`a?[b]` se comporte exactement comme `a[b]` au runtime (l'indexation renvoie déjà null pour un conteneur null ou un index hors bornes), mais type explicitement le résultat `element | null`. Utile surtout en mode strict, où `a[b]` est sinon typé non-null : `a?[b]` permet de réintroduire la nullité (et évite le déballage primitif qui ferait planter sur un slot null). Le résultat nullable n'est donc pas une lvalue.

Le `?` doit être collé au `[` pour lever l'ambiguïté avec le ternaire `cond ? [1, 2] : [3, 4]` dont les branches sont des littéraux tableau.

Fonctionne pour les tableaux, maps, chaînes, tranches, objets/classes (indexation par nom de membre) et le chaînage `a?[0]?[1]`.